### PR TITLE
Remove call to removed method in documentation

### DIFF
--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -62,7 +62,7 @@ file:
 
 ```php
 $app->pipe(\Mezzio\Session\SessionMiddleware::class);
-$app->pipeRoutingMiddleware();
+$app->pipe(\Mezzio\Router\Middleware\RouteMiddleware::class);
 ```
 
 This will generally be an inexpensive operation; since the middleware uses a


### PR DESCRIPTION
Calling `$app->pipeRoutingMiddleware()` is no longer possible and is misleading, because the method is not present since `mezzio/mezzio:3.0.0` .
Here is a reference to the pull request: https://github.com/zendframework/zend-expressive/pull/543
And one to the changelog: https://github.com/mezzio/mezzio/releases/tag/3.0.0