### PR TITLE
Add extra SessionInterface::class request attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to this project will be documented in this file, in reverse 
 
 ### Added
 
+- [#5](https://github.com/mezzio/mezzio-session/pull/5) adds the ability to use pull the session instance using the request attribute `Mezzio\Session\SessionInterface::class` (in addition to `Mezzio\Sesson\SessionMiddleware::SESSION_ATTRIBUTE` or `session`). This makes usage more consistent with other Mezzio packages, where interface or class names are used for request attributes. The original values will be kept, as they allow substituting other session implementations.
+
 - [#10](https://github.com/mezzio/mezzio-session/pull/10) adds a new property and method to the `Mezzion\Session\Persistence\SessionCookieAwareTrait`, `private $deleteCookieOnEmptySession = false`, and `public function isDeleteCookieOnEmptySession(): bool`; implementations that want to enforce deleting the session cookie when the session is empty can toggle the property flag to make this behavior occur.
 
 - [zendframework/zend-expressive-session#38](https://github.com/zendframework/zend-expressive-session/pull/38) adds `InitializeSessionIdInterface` and `InitializePersistenceIdInterface`. These add `initializeId()` methods to session and persistence, allowing developers to access new or regenerated session IDs before the session is persisted.

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -36,7 +36,10 @@ class SessionMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $session = new LazySession($this->persistence, $request);
-        $response = $handler->handle($request->withAttribute(self::SESSION_ATTRIBUTE, $session));
+        $response = $handler->handle(
+            $request->withAttribute(self::SESSION_ATTRIBUTE, $session)
+                ->withAttribute(SessionInterface::class, $session)
+        );
         return $this->persistence->persistSession($session, $response);
     }
 }

--- a/docs/book/middleware.md
+++ b/docs/book/middleware.md
@@ -37,7 +37,8 @@ class SessionMiddleware implements MiddlewareInterface
     {
         $session = new LazySession($this->persistence, $request);
         $response = $handler->handle(
-            $request->withAttribute(self::SESSION_ATTRIBUTE, $session)
+            $request
+                ->withAttribute(self::SESSION_ATTRIBUTE, $session)
                 ->withAttribute(SessionInterface::class, $session)
         );
         return $this->persistence->persistSession($session, $response);

--- a/docs/book/session.md
+++ b/docs/book/session.md
@@ -180,7 +180,8 @@ to seed the session cookie lifetime, if present.
 
 Session containers will typically be passed to your middleware using the
 [SessionMiddleware](middleware.md), via the
-`Mezzio\Session\SessionMiddleware::SESSION_ATTRIBUTE` ("session")
+`Mezzio\Session\SessionMiddleware::SESSION_ATTRIBUTE` ("session") or the
+`Mezzio\Session\SessionInterface::class` ("Mezzio\Session\SessionInterface")
 request attribute.
 
 Once you have the container, you can check for data:

--- a/docs/book/session.md
+++ b/docs/book/session.md
@@ -181,8 +181,8 @@ to seed the session cookie lifetime, if present.
 Session containers will typically be passed to your middleware using the
 [SessionMiddleware](middleware.md), via the
 `Mezzio\Session\SessionMiddleware::SESSION_ATTRIBUTE` ("session") or the
-`Mezzio\Session\SessionInterface::class` ("Mezzio\Session\SessionInterface")
-request attribute.
+`Mezzio\Session\SessionInterface::class` ("Mezzio\Session\SessionInterface";
+available since version 1.4.0) request attribute.
 
 Once you have the container, you can check for data:
 

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -32,7 +32,10 @@ class SessionMiddleware implements MiddlewareInterface
     public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
     {
         $session = new LazySession($this->persistence, $request);
-        $response = $handler->handle($request->withAttribute(self::SESSION_ATTRIBUTE, $session));
+        $response = $handler->handle(
+            $request->withAttribute(self::SESSION_ATTRIBUTE, $session)
+                ->withAttribute(SessionInterface::class, $session)
+        );
         return $this->persistence->persistSession($session, $response);
     }
 }

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -33,7 +33,8 @@ class SessionMiddleware implements MiddlewareInterface
     {
         $session = new LazySession($this->persistence, $request);
         $response = $handler->handle(
-            $request->withAttribute(self::SESSION_ATTRIBUTE, $session)
+            $request
+                ->withAttribute(self::SESSION_ATTRIBUTE, $session)
                 ->withAttribute(SessionInterface::class, $session)
         );
         return $this->persistence->persistSession($session, $response);

--- a/test/SessionMiddlewareTest.php
+++ b/test/SessionMiddlewareTest.php
@@ -11,6 +11,7 @@ declare(strict_types=1);
 namespace MezzioTest\Session;
 
 use Mezzio\Session\LazySession;
+use Mezzio\Session\SessionInterface;
 use Mezzio\Session\SessionMiddleware;
 use Mezzio\Session\SessionPersistenceInterface;
 use PHPUnit\Framework\TestCase;
@@ -33,6 +34,9 @@ class SessionMiddlewareTest extends TestCase
         $request = $this->prophesize(ServerRequestInterface::class);
         $request
             ->withAttribute(SessionMiddleware::SESSION_ATTRIBUTE, Argument::type(LazySession::class))
+            ->will([$request, 'reveal']);
+        $request
+            ->withAttribute(SessionInterface::class, Argument::type(LazySession::class))
             ->will([$request, 'reveal']);
 
         $response = $this->prophesize(ResponseInterface::class);


### PR DESCRIPTION
The `SessionInterface` instance is passed along as a request attribute with name `SessionMiddleware::SESSION_ATTRIBUTE` i.e. the string 'session'. Adding an extra `SessionInterface::class` attribute would not be a BC and could make sense for a couple (and a half) of reasons:

1. some (read "I", possibly others) may prefer fq interface names when passing around objects;
2. the name 'session' is the most obvious choice of course, but it could be easily accidentally overwritten;
3. fetching the session instance from the request by using the name `SessionMiddleware::SESSION_ATTRIBUTE` takes a bit more typing (ok, ok, this is silly...)  and less hinting than ``SessionInterface::class``. It is also seems strange to me importing from a middleware (even if only a constant) inside a request-handler class. The direct use of the string 'session' avoids that, but I believe it's always preferable to use iface/class constants and/or iface names.

One of the reason for the usage of the string `session` could be the fact that external implementations of php session could use it as an unwritten convention, so swapping packages would mean no rewrite, but then we are not sure what the interface is. Using an interface name makes it more clear what we are using.

PS
If no others feel this way this PR can be killed instantly, no explaination needed... :-) kind regards