### PR TITLE
Add persistence traits

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -32,12 +32,14 @@
     },
     "require": {
         "php": "^7.1",
+        "dflydev/fig-cookies": "^1.0.2 || ^2.0",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-diactoros": "^2.2",
         "phpunit/phpunit": "^6.5.5"
     },
     "conflict": {

--- a/src/Persistence/CacheHeadersGeneratorTrait.php
+++ b/src/Persistence/CacheHeadersGeneratorTrait.php
@@ -1,0 +1,184 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-session for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Session\Persistence;
+
+use Psr\Http\Message\ResponseInterface;
+
+use function filemtime;
+use function getlastmod;
+use function gmdate;
+use function sprintf;
+use function time;
+
+/**
+ * Provides cache-headers generation methods to consumer classes.
+ */
+trait CacheHeadersGeneratorTrait
+{
+    /**
+     * The time-to-live for cached session pages in minutes as specified in php
+     * ini settings. This has no effect for 'nocache' limiter.
+     *
+     * @var int
+     */
+    private $cacheExpire;
+
+    /**
+     * The cache control method used for session pages as specified in php ini
+     * settings. It may be one of the following values: 'nocache', 'private',
+     * 'private_no_expire', or 'public'.
+     *
+     * @var string
+     */
+    private $cacheLimiter;
+
+    /** @var array */
+    private static $supportedCacheLimiters = [
+        'nocache'           => true,
+        'public'            => true,
+        'private'           => true,
+        'private_no_expire' => true,
+    ];
+
+    /** @var false|string */
+    private $lastModified;
+
+    /**
+     * HTTP date format to be used in `gmdate` calls for creating valid header
+     * values.
+     *
+     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+     * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
+     */
+    private static $httpDateFormat = 'D, d M Y H:i:s T';
+
+    /**
+     * This unusual past date value is taken from the php-engine source code and
+     * used "as is" for consistency. BTW, it's Sebastian Bergmann's birthdate.
+     *
+     * @see https://github.com/php/php-src/blob/php-7.4.4/ext/session/session.c#L1193
+     */
+    private static $cachePastDate = 'Thu, 19 Nov 1981 08:52:00 GMT';
+
+    /**
+     * Add cache headers to the response when needed.
+     */
+    private function addCacheHeadersToResponse(ResponseInterface $response) : ResponseInterface
+    {
+        if (! $this->cacheLimiter || $this->responseAlreadyHasCacheHeaders($response)) {
+            return $response;
+        }
+
+        $cacheHeaders = $this->generateCacheHeaders();
+        foreach ($cacheHeaders as $name => $value) {
+            if ($value !== false) {
+                $response = $response->withHeader($name, $value);
+            }
+        }
+
+        return $response;
+    }
+
+    /**
+     * Generate cache http headers for this instance's session cache-limiter and
+     * cache-expire values.
+     */
+    private function generateCacheHeaders() : array
+    {
+        // Unsupported cache_limiter => do not generate cache headers
+        if (! isset(self::$supportedCacheLimiters[$this->cacheLimiter])) {
+            return [];
+        }
+
+        // cache_limiter: 'nocache'
+        if ('nocache' === $this->cacheLimiter) {
+            return [
+                'Expires'       => self::$cachePastDate,
+                'Cache-Control' => 'no-store, no-cache, must-revalidate',
+                'Pragma'        => 'no-cache',
+            ];
+        }
+
+        $maxAge       = 60 * $this->cacheExpire;
+        $lastModified = $this->getLastModified();
+
+        // cache_limiter: 'public'
+        if ('public' === $this->cacheLimiter) {
+            return [
+                'Expires'       => gmdate(self::$httpDateFormat, time() + $maxAge),
+                'Cache-Control' => sprintf('public, max-age=%d', $maxAge),
+                'Last-Modified' => $lastModified,
+            ];
+        }
+
+        // cache_limiter: 'private'
+        if ('private' === $this->cacheLimiter) {
+            return [
+                'Expires'       => self::$cachePastDate,
+                'Cache-Control' => sprintf('private, max-age=%d', $maxAge),
+                'Last-Modified' => $lastModified,
+            ];
+        }
+
+        // last possible case, cache_limiter = 'private_no_expire'
+        return [
+            'Cache-Control' => sprintf('private, max-age=%d', $maxAge),
+            'Last-Modified' => $lastModified,
+        ];
+    }
+
+    /**
+     * Return the Last-Modified header line based on main script of execution
+     * modified time. If unable to get a valid timestamp we use this class file
+     * modification time as fallback.
+     *
+     * @return string|false
+     */
+    private function getLastModified()
+    {
+        if (isset($this->lastModified)) {
+            return $this->lastModified;
+        }
+
+        $lastmod = getlastmod() ?: filemtime(__FILE__);
+        $lastmod ? gmdate(self::$httpDateFormat, $lastmod) : false;
+        $this->lastModified = $lastmod;
+
+        return $lastmod;
+    }
+
+    /**
+     * Check if the response already carries cache headers
+     */
+    private function responseAlreadyHasCacheHeaders(ResponseInterface $response) : bool
+    {
+        return $response->hasHeader('Expires')
+            || $response->hasHeader('Last-Modified')
+            || $response->hasHeader('Cache-Control')
+            || $response->hasHeader('Pragma');
+    }
+
+    /**
+     * @internal
+     */
+    public static function getHttpDateFormat() : string
+    {
+        return self::$httpDateFormat;
+    }
+
+    /**
+     * @internal
+     */
+    public static function getCachePastDate() : string
+    {
+        return self::$cachePastDate;
+    }
+}

--- a/src/Persistence/CacheHeadersGeneratorTrait.php
+++ b/src/Persistence/CacheHeadersGeneratorTrait.php
@@ -52,23 +52,6 @@ trait CacheHeadersGeneratorTrait
     private $lastModified;
 
     /**
-     * HTTP date format to be used in `gmdate` calls for creating valid header
-     * values.
-     *
-     * @see https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
-     * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
-     */
-    private static $httpDateFormat = 'D, d M Y H:i:s T';
-
-    /**
-     * This unusual past date value is taken from the php-engine source code and
-     * used "as is" for consistency. BTW, it's Sebastian Bergmann's birthdate.
-     *
-     * @see https://github.com/php/php-src/blob/php-7.4.4/ext/session/session.c#L1193
-     */
-    private static $cachePastDate = 'Thu, 19 Nov 1981 08:52:00 GMT';
-
-    /**
      * Add cache headers to the response when needed.
      */
     private function addCacheHeadersToResponse(ResponseInterface $response) : ResponseInterface
@@ -101,7 +84,7 @@ trait CacheHeadersGeneratorTrait
         // cache_limiter: 'nocache'
         if ('nocache' === $this->cacheLimiter) {
             return [
-                'Expires'       => self::$cachePastDate,
+                'Expires'       => Http::CACHE_PAST_DATE,
                 'Cache-Control' => 'no-store, no-cache, must-revalidate',
                 'Pragma'        => 'no-cache',
             ];
@@ -113,7 +96,7 @@ trait CacheHeadersGeneratorTrait
         // cache_limiter: 'public'
         if ('public' === $this->cacheLimiter) {
             return [
-                'Expires'       => gmdate(self::$httpDateFormat, time() + $maxAge),
+                'Expires'       => gmdate(Http::DATE_FORMAT, time() + $maxAge),
                 'Cache-Control' => sprintf('public, max-age=%d', $maxAge),
                 'Last-Modified' => $lastModified,
             ];
@@ -122,7 +105,7 @@ trait CacheHeadersGeneratorTrait
         // cache_limiter: 'private'
         if ('private' === $this->cacheLimiter) {
             return [
-                'Expires'       => self::$cachePastDate,
+                'Expires'       => Http::CACHE_PAST_DATE,
                 'Cache-Control' => sprintf('private, max-age=%d', $maxAge),
                 'Last-Modified' => $lastModified,
             ];
@@ -149,7 +132,7 @@ trait CacheHeadersGeneratorTrait
         }
 
         $lastmod = getlastmod() ?: filemtime(__FILE__);
-        $lastmod ? gmdate(self::$httpDateFormat, $lastmod) : false;
+        $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;
         $this->lastModified = $lastmod;
 
         return $lastmod;
@@ -164,21 +147,5 @@ trait CacheHeadersGeneratorTrait
             || $response->hasHeader('Last-Modified')
             || $response->hasHeader('Cache-Control')
             || $response->hasHeader('Pragma');
-    }
-
-    /**
-     * @internal
-     */
-    public static function getHttpDateFormat() : string
-    {
-        return self::$httpDateFormat;
-    }
-
-    /**
-     * @internal
-     */
-    public static function getCachePastDate() : string
-    {
-        return self::$cachePastDate;
     }
 }

--- a/src/Persistence/CacheHeadersGeneratorTrait.php
+++ b/src/Persistence/CacheHeadersGeneratorTrait.php
@@ -132,10 +132,9 @@ trait CacheHeadersGeneratorTrait
         }
 
         $lastmod = getlastmod() ?: filemtime(__FILE__);
-        $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;
-        $this->lastModified = $lastmod;
+        $this->lastModified = $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;
 
-        return $lastmod;
+        return $this->lastModified;
     }
 
     /**

--- a/src/Persistence/Http.php
+++ b/src/Persistence/Http.php
@@ -1,0 +1,39 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-session for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Session\Persistence;
+
+/**
+ * Provides commonly used HTTP related constants.
+ */
+class Http
+{
+    /**
+     * HTTP date format to be used in `gmdate` calls for creating valid header
+     * values.
+     *
+     * òsee https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+     * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
+     */
+    public const DATE_FORMAT = 'D, d M Y H:i:s T';
+
+    /**
+     * The header formatted version of the Unix Epoch for generic past-date.
+     */
+    public const UNIX_EPOCH = 'Thu, 01 Jan 1970 00:00:00 GMT';
+
+    /**
+     * This unusual past date value is taken from the php-engine source code and
+     * used "as is" for consistency. BTW, it's Sebastian Bergmann's birthdate.
+     *
+     * @see https://github.com/php/php-src/blob/php-7.4.4/ext/session/session.c#L1193
+     */
+    public const CACHE_PAST_DATE = 'Thu, 19 Nov 1981 08:52:00 GMT';
+}

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -114,9 +114,13 @@ trait SessionCookieAwareTrait
             );
         }
 
-        return $cookieLifetime
-            ? $sessionCookie->withExpires(time() + $cookieLifetime)
-            : $sessionCookie;
+        if ($cookieLifetime) {
+            $sessionCookie = $sessionCookie
+                ->withExpires(time() + $cookieLifetime)
+                ->withMaxAge($cookieLifetime);
+        }
+
+        return $sessionCookie;
     }
 
     private function getSessionCookieLifetime(SessionInterface $session) : int

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -12,8 +12,8 @@ namespace Mezzio\Session\Persistence;
 
 use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\FigResponseCookies;
-use Dflydev\FigCookies\SetCookie;
 use Dflydev\FigCookies\Modifier\SameSite;
+use Dflydev\FigCookies\SetCookie;
 use Mezzio\Session\SessionCookiePersistenceInterface;
 use Mezzio\Session\SessionInterface;
 use Psr\Http\Message\ResponseInterface;

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -62,7 +62,7 @@ trait SessionCookieAwareTrait
      * In each case, if the value is not found, it falls back to generating a
      * new session identifier.
      */
-    private function getSessionCookieFromRequest(ServerRequestInterface $request) : string
+    private function getSessionCookieValueFromRequest(ServerRequestInterface $request) : string
     {
         if ('' === $request->getHeaderLine('Cookie')) {
             return $request->getCookieParams()[$this->cookieName] ?? '';
@@ -76,7 +76,7 @@ trait SessionCookieAwareTrait
      *
      * @param string $cookieValue The session-cookie value, tipically the session id
      */
-    private function addSessionCookieToResponse(
+    private function addSessionCookieHeaderToResponse(
         ResponseInterface $response,
         string $cookieValue,
         SessionInterface $session

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -84,7 +84,6 @@ trait SessionCookieAwareTrait
         return FigResponseCookies::set(
             $response,
             $this->createSessionCookieForResponse(
-                $this->cookieName,
                 $cookieValue,
                 $this->getSessionCookieLifetime($session)
             )

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -1,0 +1,134 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-session for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace Mezzio\Session\Persistence;
+
+use Dflydev\FigCookies\FigRequestCookies;
+use Dflydev\FigCookies\FigResponseCookies;
+use Dflydev\FigCookies\SetCookie;
+use Dflydev\FigCookies\Modifier\SameSite;
+use Mezzio\Session\SessionCookiePersistenceInterface;
+use Mezzio\Session\SessionInterface;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+
+use function class_exists;
+use function method_exists;
+use function time;
+
+/**
+ * Provides methods for retrieving the session-cookie value from the request and
+ * decorating the response with a session-cookie header.
+ */
+trait SessionCookieAwareTrait
+{
+    /** @var string */
+    private $cookieName;
+
+    /** @var int */
+    private $cookieLifetime = 0;
+
+    /** @var string */
+    private $cookiePath = '/';
+
+    /** @var string|null */
+    private $cookieDomain;
+
+    /** @var bool */
+    private $cookieSecure = false;
+
+    /** @var bool */
+    private $cookieHttpOnly = false;
+
+    /** @var string */
+    private $cookieSameSite = '';
+
+    /**
+     * Retrieve the session cookie value.
+     *
+     * Cookie headers may or may not be present, based on SAPI.  For instance,
+     * under Swoole, they are omitted, but the cookie parameters are present.
+     * As such, this method uses FigRequestCookies to retrieve the cookie value
+     * only if the Cookie header is present. Otherwise, it falls back to the
+     * request cookie parameters.
+     *
+     * In each case, if the value is not found, it falls back to generating a
+     * new session identifier.
+     */
+    private function getSessionCookieFromRequest(ServerRequestInterface $request) : string
+    {
+        if ('' === $request->getHeaderLine('Cookie')) {
+            return $request->getCookieParams()[$this->cookieName] ?? '';
+        }
+
+        return FigRequestCookies::get($request, $this->cookieName)->getValue() ?? '';
+    }
+
+    /**
+     * Return a cloned response decorated with the session-cookie.
+     *
+     * @param string $cookieValue The session-cookie value, tipically the session id
+     */
+    private function addSessionCookieToResponse(
+        ResponseInterface $response,
+        string $cookieValue,
+        SessionInterface $session
+    ) : ResponseInterface {
+        return FigResponseCookies::set(
+            $response,
+            $this->createSessionCookieForResponse(
+                $this->cookieName,
+                $cookieValue,
+                $this->getSessionCookieLifetime($session)
+            )
+        );
+    }
+
+    /**
+     * Build a SetCookie instance for client session persistence.
+     *
+     * @param string $cookieValue The cookie value
+     * @param int|null $cookieLifetime A session cookie lifetime other than the default
+     */
+    private function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0) : SetCookie
+    {
+        $sessionCookie = SetCookie::create($this->cookieName)
+            ->withValue($cookieValue)
+            ->withPath($this->cookiePath)
+            ->withDomain($this->cookieDomain)
+            ->withSecure($this->cookieSecure)
+            ->withHttpOnly($this->cookieHttpOnly);
+
+        if ($this->cookieSameSite
+            && method_exists($sessionCookie, 'withSameSite')
+            && class_exists(SameSite::class)
+        ) {
+            $sessionCookie = $sessionCookie->withSameSite(
+                SameSite::fromString($this->cookieSameSite)
+            );
+        }
+
+        return $cookieLifetime
+            ? $sessionCookie->withExpires(time() + $cookieLifetime)
+            : $sessionCookie;
+    }
+
+    private function getSessionCookieLifetime(SessionInterface $session) : int
+    {
+        $lifetime = (int) $this->cookieLifetime;
+        if ($session instanceof SessionCookiePersistenceInterface
+            && $session->has(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY)
+        ) {
+            $lifetime = $session->getSessionLifetime();
+        }
+
+        return $lifetime > 0 ? $lifetime : 0;
+    }
+}

--- a/test/Persistence/CacheHeadersGeneratorTraitTest.php
+++ b/test/Persistence/CacheHeadersGeneratorTraitTest.php
@@ -1,0 +1,287 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-diactoros for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-diactoros/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Session\Persistence;
+
+use Laminas\Diactoros\Response;
+use Mezzio\Session\Persistence\CacheHeadersGeneratorTrait;
+use Mezzio\Session\Persistence\Http;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use ReflectionClass;
+
+class CacheHeadersGeneratorTraitTest extends TestCase
+{
+    const GMDATE_REGEXP = '/^'
+        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sun), '
+        . '[0-3][0-9] '
+        . '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '
+        . '[0-9]{4} '
+        . '[0-2][0-9]:[0-5][0-9]:[0-5][0-9] '
+        . 'GMT'
+    . '$/';
+
+    protected function setUp() : void
+    {
+    }
+
+    protected function createConsumerInstance(
+        int $cacheExpire = 180,
+        string $cacheLimiter = '',
+        string $lastModified = null
+    ) {
+        return new class($cacheExpire, $cacheLimiter, $lastModified) {
+
+            use CacheHeadersGeneratorTrait {
+                addCacheHeadersToResponse as trait_addCacheHeadersToResponse;
+                responseAlreadyHasCacheHeaders as trait_responseAlreadyHasCacheHeaders;
+                getLastModified as trait_getLastModified;
+            }
+
+            public function __construct(int $cacheExpire, string $cacheLimiter, string $lastModified = null)
+            {
+                $this->cacheExpire  = $cacheExpire;
+                $this->cacheLimiter = $cacheLimiter;
+                $this->lastModified = $lastModified;
+            }
+
+            public function addCacheHeadersToResponse(ResponseInterface $response) : ResponseInterface
+            {
+                return $this->trait_addCacheHeadersToResponse($response);
+            }
+
+            public function getLastModified()
+            {
+                return $this->trait_getLastModified();
+            }
+
+            public function responseAlreadyHasCacheHeaders(ResponseInterface $response) : bool
+            {
+                return $this->trait_responseAlreadyHasCacheHeaders($response);
+            }
+        };
+    }
+
+    public function testLastModified()
+    {
+        // test autodiscover lastModified value
+        $consumer = $this->createConsumerInstance();
+        self::assertSame($this->getExpectedLastModified(), $consumer->getLastModified());
+
+        // test injected lastModified value
+        $consumer = $this->createConsumerInstance(60, '', Http::UNIX_EPOCH);
+        self::assertSame(Http::UNIX_EPOCH, $consumer->getLastModified());
+    }
+
+    /**
+     * @dataProvider provideCacheHeaderValues
+     */
+    public function testResponseAlreadyHasCacheHeaders($name, $value, $expected)
+    {
+        $consumer = $this->createConsumerInstance();
+
+        $response = new Response();
+        $response = $response->withHeader($name, $value);
+
+        self::assertSame($expected, $consumer->responseAlreadyHasCacheHeaders($response));
+
+        $response = $response->withoutHeader($name);
+        self::assertFalse($consumer->responseAlreadyHasCacheHeaders($response));
+    }
+
+    public function provideCacheHeaderValues()
+    {
+        return [
+            'expires'       => [ 'Expires', 'Sat, 14 Apr 1945 00:00:00 GMT', true],
+            'last-modified' => [ 'Last-Modified', 'Sat, 25 Mar 1972 00:00:00 GMT', true],
+            'cache-control' => [ 'Cache-Control', 'private, max-age=3600', true],
+            'pragma'        => [ 'Pragma', 'no-cache', true],
+            'other-header'  => [ 'Content-Language', 'en', false],
+        ];
+    }
+
+    public function testDontAddCacheHeadersForEmptyOrUnsupportedCacheLimiter()
+    {
+        // do not add dataProvider for 2 cases
+        $cacheLimuiters = ['', 'unsupported'];
+
+        foreach ($cacheLimuiters as $cacheLimiter) {
+            $consumer = $this->createConsumerInstance(60, $cacheLimiter);
+            $response = $consumer->addCacheHeadersToResponse(new Response());
+
+            self::assertFalse($response->hasHeader('Expires'));
+            self::assertFalse($response->hasHeader('Last-Modified'));
+            self::assertFalse($response->hasHeader('Cache-Control'));
+            self::assertFalse($response->hasHeader('Pragma'));
+        }
+    }
+
+    public function testDontAddExtraCacheHeadersIfRespnseAlreadyHasAny()
+    {
+        $consumer = $this->createConsumerInstance(60, 'public');
+
+        // already has Last-Modified
+        $response = (new Response)->withHeader('Last-Modified', gmdate(Http::DATE_FORMAT));
+        $response = $consumer->addCacheHeadersToResponse($response);
+        $this->assertFalse($response->hasHeader('Pragma'));
+        $this->assertFalse($response->hasHeader('Expires'));
+        $this->assertFalse($response->hasHeader('Cache-Control'));
+
+        // already has Cache-Control
+        $response = (new Response)->withHeader('Cache-Control', 'public, max-age=3600');
+        $response = $consumer->addCacheHeadersToResponse($response);
+        $this->assertFalse($response->hasHeader('Pragma'));
+        $this->assertFalse($response->hasHeader('Expires'));
+        $this->assertFalse($response->hasHeader('Last-Modified'));
+
+        // already has Pragma
+        $response = (new Response)->withHeader('Pragma', 'no-cache');
+        $response = $consumer->addCacheHeadersToResponse($response);
+        $this->assertFalse($response->hasHeader('Expires'));
+        $this->assertFalse($response->hasHeader('Cache-Control'));
+        $this->assertFalse($response->hasHeader('Last-Modified'));
+
+        // already has Expires
+        $response = (new Response)->withHeader('Expires', gmdate(Http::DATE_FORMAT));
+        $response = $consumer->addCacheHeadersToResponse($response);
+        $this->assertFalse($response->hasHeader('Pragma'));
+        $this->assertFalse($response->hasHeader('Cache-Control'));
+        $this->assertFalse($response->hasHeader('Last-Modified'));
+    }
+
+    public function testAddCacheHeadersForNoCacheCacheLimiter()
+    {
+        $consumer = $this->createConsumerInstance(60, 'nocache');
+        $response = $consumer->addCacheHeadersToResponse(new Response());
+
+        self::assertSame(Http::CACHE_PAST_DATE, $response->getHeaderLine('Expires'));
+        self::assertSame('no-store, no-cache, must-revalidate', $response->getHeaderLine('Cache-Control'));
+        self::assertFalse($response->hasHeader('Last-Modified'));
+        self::assertSame('no-cache', $response->getHeaderLine('Pragma'));
+    }
+
+    public function testAddCacheHeadersForPublicCacheLimiter()
+    {
+        $cacheExpire = 60;
+        $maxAge      = 60 * $cacheExpire;
+
+        $consumer = $this->createConsumerInstance($cacheExpire, 'public');
+        $response = $consumer->addCacheHeadersToResponse(new Response());
+
+        $lastModified = $this->getExpectedLastModified() ?: '';
+
+        self::assertRegExp(self::GMDATE_REGEXP, $response->getHeaderLine('Expires'));
+        self::assertSame(sprintf('public, max-age=%d', $maxAge), $response->getHeaderLine('Cache-Control'));
+        self::assertSame($lastModified, $response->getHeaderLine('Last-Modified'));
+        self::assertFalse($response->hasHeader('Pragma'));
+    }
+
+    public function testAddCacheHeadersForPrivateCacheLimiter()
+    {
+        $cacheExpire = 60;
+        $maxAge      = 60 * $cacheExpire;
+
+        $consumer = $this->createConsumerInstance($cacheExpire, 'private');
+        $response = $consumer->addCacheHeadersToResponse(new Response());
+
+        $lastModified = $this->getExpectedLastModified() ?: '';
+
+        self::assertRegExp(self::GMDATE_REGEXP, $response->getHeaderLine('Expires'));
+        self::assertSame(sprintf('private, max-age=%d', $maxAge), $response->getHeaderLine('Cache-Control'));
+        self::assertSame($lastModified, $response->getHeaderLine('Last-Modified'));
+        self::assertFalse($response->hasHeader('Pragma'));
+    }
+
+//    /**
+//     * @dataProvider provideCacheLimiterValues
+//     */
+//    public function testResponseCacheHeadersToResponseWithValidCacheLimiters(
+//        $cacheExpire,
+//        $cacheLimiter,
+//        $expected_expires,
+//        $expected_lastModified,
+//        $expected_cacheControl,
+//        $expected_pragma
+//    ) {
+//        $consumer = $this->createConsumerInstance($cacheExpire, $cacheLimiter);
+//
+//        $response = $consumer->addCacheHeadersToResponse(new Response());
+//
+//        self::assertSame($expected_expires,      $response->getHeaderLine('Expires'));
+//        self::assertSame($expected_lastModified, $response->getHeaderLine('Last-Modified'));
+//        self::assertSame($expected_cacheControl, $response->getHeaderLine('Cache-Control'));
+//        self::assertSame($expected_pragma,       $response->getHeaderLine('Pragma'));
+//    }
+
+    public function provideCacheLimiterValues()
+    {
+        $cacheExpire  = 60;
+        $maxAge       = (string) (60 * $cacheExpire);
+        $lastModified = $this->getLastModified();
+
+        return [
+            'empty' => [
+                'cache_expire' => $cacheExpire,
+                'cache_limiter' => '',
+                'expected_expires' => '',
+                'expected_last_modified' => '',
+                'expected_cache_control' => '',
+                'expected_pragma' => '',
+            ],
+            'not-valid' => [
+                'cache_expire' => $cacheExpire,
+                'cache_limiter' => 'not-valid',
+                'expected_expires' => '',
+                'expected_last_modified' => '',
+                'expected_cache_control' => '',
+                'expected_pragma' => '',
+            ],
+            'nocache' => [
+                'cache_expire' => $cacheExpire,
+                'cache_limiter' => 'nocache',
+                'expected_expires' => Http::CACHE_PAST_DATE,
+                'expected_last_modified' => '',
+                'expected_cache_control' => 'no-store, no-cache, must-revalidate',
+                'expected_pragma' => 'no-cache',
+            ],
+            'public' => [
+                'cache_expire' => $cacheExpire,
+                'cache_limiter' => 'public',
+                'expected_expires' => Http::CACHE_PAST_DATE,
+                'expected_last_modified' => '',
+                'expected_cache_control' => 'public, max-age=' . $maxAge,
+                'expected_pragma' => '',
+            ],
+            'private' => [
+                'cache_expire' => $cacheExpire,
+                'cache_limiter' => 'private',
+                'expected_expires' => Http::CACHE_PAST_DATE,
+                'expected_last_modified' => '',
+                'expected_cache_control' => 'private, max-age=' . $maxAge,
+                'expected_pragma' => '',
+            ],
+        ];
+    }
+
+    /**
+     * @return string|false
+     */
+    private function getExpectedLastModified()
+    {
+        $lastmod = getlastmod();
+        if ($lastmod === false) {
+            $rc = new ReflectionClass(CacheHeadersGeneratorTrait::class);
+            $classFile = $rc->getFileName();
+            $lastmod = filemtime($classFile);
+        }
+
+        return $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;
+    }
+}

--- a/test/Persistence/SessionCookieAwareTraitTest.php
+++ b/test/Persistence/SessionCookieAwareTraitTest.php
@@ -1,0 +1,333 @@
+<?php
+
+/**
+ * @see       https://github.com/laminas/laminas-diactoros for the canonical source repository
+ * @copyright https://github.com/laminas/laminas-diactoros/blob/master/COPYRIGHT.md
+ * @license   https://github.com/laminas/laminas-diactoros/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Session\Persistence;
+
+use Dflydev\FigCookies\Cookie;
+use Dflydev\FigCookies\FigRequestCookies;
+use Dflydev\FigCookies\FigResponseCookies;
+use Dflydev\FigCookies\Modifier\SameSite;
+use Dflydev\FigCookies\SetCookie;
+use Dflydev\FigCookies\SetCookies;
+use Laminas\Diactoros\ServerRequest;
+use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequestFactory;
+use Mezzio\Session\Persistence\SessionCookieAwareTrait;
+use Mezzio\Session\Session;
+use Mezzio\Session\SessionInterface;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Message\ResponseInterface;
+
+class SessionCookieAwareTraitTest extends TestCase
+{
+    const EXPIRE_REGEXP = '/'
+        . 'Expires\='
+        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sun), '
+        . '[0-3][0-9] '
+        . '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '
+        . '[0-9]{4} '
+        . '[0-2][0-9]:[0-5][0-9]:[0-5][0-9] '
+        . 'GMT'
+    . '/i';
+
+    private const COOKIE_NAME = 'SESSIONCOOKIENAME';
+    private const COOKIE_LIFETIME = 0;
+    private const COOKIE_PATH = '/';
+    private const COOKIE_DOMAIN = null;
+    private const COOKIE_SECURE = false;
+    private const COOKIE_HTTPONLY = false;
+    private const COOKIE_SAMESITE = '';
+
+    protected function setUp() : void
+    {
+    }
+
+    protected function createConsumerInstance(
+        string $cookieName = null,
+        int $cookieLifetime = null,
+        string $cookiePath = null,
+        string $cookieDomain = null,
+        bool $cookieSecure = null,
+        bool $cookieHttpOnly = null,
+        string $cookieSameSite = null
+    ) {
+        return new class(
+            $cookieName ?? self::COOKIE_NAME,
+            $cookieLifetime ?? self::COOKIE_LIFETIME,
+            $cookiePath ?? self::COOKIE_PATH,
+            $cookieDomain ?? self::COOKIE_DOMAIN,
+            $cookieSecure ?? self::COOKIE_SECURE,
+            $cookieHttpOnly ?? self::COOKIE_HTTPONLY,
+            $cookieSameSite ?? self::COOKIE_SAMESITE
+        ) {
+            use SessionCookieAwareTrait {
+                getSessionCookieValueFromRequest as trait_getSessionCookieValueFromRequest;
+                addSessionCookieHeaderToResponse as trait_addSessionCookieHeaderToResponse;
+                createSessionCookieForResponse as trait_createSessionCookieForResponse;
+                getSessionCookieLifetime as trait_getSessionCookieLifetime;
+            }
+
+            public function __construct(
+                string $cookieName,
+                int $cookieLifetime = 0,
+                string $cookiePath = '/',
+                string $cookieDomain = null,
+                bool $cookieSecure = false,
+                bool $cookieHttpOnly = false,
+                string $cookieSameSite = ''
+            ) {
+                $this->cookieName     = $cookieName;
+                $this->cookieLifetime = $cookieLifetime;
+                $this->cookiePath     = $cookiePath;
+                $this->cookieDomain   = $cookieDomain;
+                $this->cookieSecure   = $cookieSecure;
+                $this->cookieHttpOnly = $cookieHttpOnly;
+                $this->cookieSameSite = $cookieSameSite;
+            }
+
+            public function getSessionCookieValueFromRequest(ServerRequestInterface $request) : string
+            {
+                return $this->trait_getSessionCookieValueFromRequest($request);
+            }
+
+            public function addSessionCookieHeaderToResponse(
+                ResponseInterface $response,
+                string $cookieValue,
+                SessionInterface $session
+            ) : ResponseInterface {
+                return $this->trait_addSessionCookieHeaderToResponse($response, $cookieValue, $session);
+            }
+
+            public function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0) : SetCookie
+            {
+                return $this->trait_createSessionCookieForResponse($cookieValue, $cookieLifetime);
+            }
+
+            public function getSessionCookieLifetime(SessionInterface $session) : int
+            {
+                return $this->trait_getSessionCookieLifetime($session);
+            }
+        };
+    }
+
+    /**
+     * @dataProvider provideRequestSessionCookieValues
+     */
+    public function testGetSessionCookieValueFromRequestUsingInjectesCookieParams(
+        string $cookieName,
+        string $cookieValue = null,
+        string $expected = null
+    ) {
+        $consumer = $this->createConsumerInstance($cookieName);
+
+        $cookies = [$cookieName => $cookieValue];
+        $request = ServerRequestFactory::fromGlobals([], [], [], $cookies, []);
+
+        self::assertSame($expected, $consumer->getSessionCookieValueFromRequest($request));
+    }
+
+    /**
+     * @dataProvider provideRequestSessionCookieValues
+     */
+    public function testGetSessionCookieValueFromRequestUsingInjectedCookieHeader(
+        string $cookieName,
+        string $cookieValue = null,
+        string $expected = null
+    ) {
+        $consumer = $this->createConsumerInstance($cookieName);
+
+        $cookie = Cookie::create($cookieName, $cookieValue);
+        $request = FigRequestCookies::set(new ServerRequest(), $cookie);
+
+        self::assertSame($expected, $consumer->getSessionCookieValueFromRequest($request));
+    }
+
+    public function provideRequestSessionCookieValues()
+    {
+        $cookieName  = 'SESSIONID';
+        $cookieNiceValue = 'some-nice-value';
+        $cookieWeirdValue = '!"£$%&/';
+
+        return [
+            [$cookieName, null, ''],
+            [$cookieName, $cookieNiceValue, $cookieNiceValue],
+            [$cookieName, $cookieWeirdValue, $cookieWeirdValue],
+        ];
+    }
+
+    public function testAddSessionCookieHeaderToResponse()
+    {
+        $cookieName  = 'ADDSESSIONCOOKIEID';
+        $cookieValue = 'set-some-cookie-value';
+        $sessionLifetime = 3600;
+
+        $consumer = $this->createConsumerInstance($cookieName);
+
+        $session = new Session([]);
+        $session->persistSessionFor($sessionLifetime);
+        $response = $consumer->addSessionCookieHeaderToResponse(new Response(), $cookieValue, $session);
+
+        $actualHeaderLine = $response->getHeaderLine('Set-Cookie');
+
+        self::assertStringStartsWith(sprintf('%s=%s; Path=/; Expires=', $cookieName, $cookieValue), $actualHeaderLine);
+        self::assertRegExp(self::EXPIRE_REGEXP, $actualHeaderLine);
+        self::assertStringEndsWith(sprintf('GMT; Max-Age=%d', $sessionLifetime), $actualHeaderLine);
+    }
+
+    /**
+     * @dataProvider provideResponseCookieHeaderLines
+     */
+    public function testCreateSessionCookieForResponse(
+        string $cookieName,
+        ?string $cookieValue,
+        int $cookieLifetime,
+        string $expectedHeaderLine
+    ) {
+        $consumer = $this->createConsumerInstance($cookieName);
+        $setCookie = $consumer->createSessionCookieForResponse(
+            $cookieValue ?? '',
+            $cookieLifetime ?? 0
+        );
+
+        $actualHeaderLine = (string) $setCookie;
+
+        self::assertSame($expectedHeaderLine, $actualHeaderLine);
+    }
+
+    public function provideResponseCookieHeaderLines()
+    {
+        $cookieName = 'PHPSESSID';
+
+        $cookieNiceValue = 'some-nice-value';
+        $cookieWeirdValue = '!"£$%&/';
+
+        return [
+            [$cookieName, null, 0, sprintf('%s=; Path=/', $cookieName)],
+            [$cookieName, $cookieNiceValue, 0, sprintf('%s=%s; Path=/', $cookieName, $cookieNiceValue)],
+            [$cookieName, $cookieWeirdValue, 0, sprintf('%s=%s; Path=/', $cookieName, urlencode($cookieWeirdValue))],
+        ];
+    }
+
+    public function testCreateSessionCookieForResponseWithExpires()
+    {
+        $cookieName  = 'PHPSESSID';
+        $cookieValue = 'a-cookie-value';
+        $cookieLifetime = 3600;
+
+        $consumer = $this->createConsumerInstance($cookieName);
+        $setCookie = $consumer->createSessionCookieForResponse($cookieValue, $cookieLifetime);
+
+        $actual = (string) $setCookie;
+
+        self::assertStringStartsWith(sprintf('%s=%s; Path=/; ', $cookieName, $cookieValue), $actual);
+        self::assertRegExp(self::EXPIRE_REGEXP, $actual);
+    }
+
+    public function testCreateSessionCookieForResponseWithDomain()
+    {
+        $cookieName  = 'PHPSESSID';
+        $cookieValue = 'a-cookie-value';
+        $cookieDomain = 'example.com';
+
+        $consumer = $this->createConsumerInstance($cookieName, null, null, $cookieDomain);
+        $setCookie = $consumer->createSessionCookieForResponse($cookieValue);
+
+        $expected = sprintf('%s=%s; Domain=%s; Path=/', $cookieName, $cookieValue, $cookieDomain);
+        $actual = (string) $setCookie;
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testCreateSessionCookieForResponseWithSecure()
+    {
+        $cookieName  = 'PHPSESSID';
+        $cookieValue = 'a-cookie-value';
+
+        $consumer = $this->createConsumerInstance($cookieName, null, null, null, true);
+        $setCookie = $consumer->createSessionCookieForResponse($cookieValue);
+
+        $expected = sprintf('%s=%s; Path=/; Secure', $cookieName, $cookieValue);
+        $actual = (string) $setCookie;
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testCreateSessionCookieForResponseWithHttpOnly()
+    {
+        $cookieName  = 'PHPSESSID';
+        $cookieValue = 'a-cookie-value';
+
+        $consumer = $this->createConsumerInstance($cookieName, null, null, null, null, true);
+        $setCookie = $consumer->createSessionCookieForResponse($cookieValue);
+
+        $expected = sprintf('%s=%s; Path=/; HttpOnly', $cookieName, $cookieValue);
+        $actual = (string) $setCookie;
+
+        self::assertSame($expected, $actual);
+    }
+
+    public function testCreateSessionCookieForResponseWithSameSiteIfSupported()
+    {
+        $cookieName  = 'PHPSESSID';
+        $cookieValue = 'a-cookie-value';
+        $cookieSameSite = 'Lax';
+
+        $consumer = $this->createConsumerInstance($cookieName, null, null, null, null, null, $cookieSameSite);
+        $setCookie = $consumer->createSessionCookieForResponse($cookieValue);
+
+        if (class_exists(SameSite::class)
+            && method_exists($setCookie, 'withSameSite')
+        ) {
+            $expected = sprintf('%s=%s; Path=/; SameSite=%s', $cookieName, $cookieValue, $cookieSameSite);
+        } else {
+            $expected = sprintf('%s=%s; Path=/', $cookieName, $cookieValue);
+        }
+        $actual = (string) $setCookie;
+
+        self::assertSame($expected, $actual);
+    }
+
+    /**
+     * @dataProvider provideSessionCookieLifetimeValues
+     */
+    public function testGetSessionCookieLifetimeReturnsExpectedResults(
+        int $cookieLifetime = null,
+        int $sessionLifetime = null,
+        int $expected = null
+    ) {
+        $consumer = $this->createConsumerInstance('SESSIONCOOKIENAME', $cookieLifetime ?? 0);
+        $session = new Session([]);
+        if (isset($sessionLifetime)) {
+            $session->persistSessionFor($sessionLifetime);
+        }
+
+        self::assertSame($expected, $consumer->getSessionCookieLifetime($session));
+    }
+
+    public function provideSessionCookieLifetimeValues()
+    {
+        return [
+            'default' => [null, null, 0],
+            'cookie=0|session=null'   => [0, null, 0],
+            'cookie=0|session=0'      => [0, 0, 0],
+            'cookie=-1|session=null'   => [-1, null, 0],
+            'cookie=-1|session=0'     => [-1, 0, 0],
+            'cookie=-1|session=-1'    => [-1, -1, 0],
+            'cookie=+60|session=null' => [60, null, 60],
+            'cookie=+60|session=0'    => [60, 0, 0],
+            'cookie=+60|session=-1'   => [60, -1, 0],
+            'cookie=+60|session=30'   => [60, 30, 30],
+            'cookie=null|session=0'   => [null, 0, 0],
+            'cookie=null|session=-1'   => [null, -1, 0],
+            'cookie=null|session=30'   => [null, 30, 30],
+        ];
+    }
+}


### PR DESCRIPTION
Extract common persistence feature into traits that can be used by consumer persistence classes.
- `CacheHeadersGeneratorTrait` extracts cache-header generation logic
- `SessionCookieAwareTrait` extract session-cookie retrieval (from request-cookie/header) and generation (into response-header) logic

[ref. issue #8](https://github.com/mezzio/mezzio-session/issues/8)