### PR TITLE
1.4.x persistence traits addon

### DIFF
--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -51,6 +51,13 @@ trait SessionCookieAwareTrait
     private $cookieSameSite = '';
 
     /**
+     * Delete cookie from browser when session becomes empty?
+     *
+     * @var bool
+     */
+    private $deleteCookieOnEmptySession = false;
+
+    /**
      * Retrieve the session cookie value.
      *
      * Cookie headers may or may not be present, based on SAPI.  For instance,
@@ -125,6 +132,10 @@ trait SessionCookieAwareTrait
 
     private function getSessionCookieLifetime(SessionInterface $session) : int
     {
+        if ($this->deleteCookieOnEmptySession && ! $session->toArray()) {
+            return -(time() - 1);
+        }
+
         $lifetime = (int) $this->cookieLifetime;
         if ($session instanceof SessionCookiePersistenceInterface
             && $session->has(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY)
@@ -133,5 +144,14 @@ trait SessionCookieAwareTrait
         }
 
         return $lifetime > 0 ? $lifetime : 0;
+    }
+
+    /**
+     * @internal
+     * @return bool whether we delete cookie from browser when session becomes empty
+     */
+    public function isDeleteCookieOnEmptySession(): bool
+    {
+        return $this->deleteCookieOnEmptySession;
     }
 }

--- a/test/Persistence/CacheHeadersGeneratorTraitTest.php
+++ b/test/Persistence/CacheHeadersGeneratorTraitTest.php
@@ -20,7 +20,7 @@ use ReflectionClass;
 class CacheHeadersGeneratorTraitTest extends TestCase
 {
     const GMDATE_REGEXP = '/^'
-        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sun), '
+        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sat), '
         . '[0-3][0-9] '
         . '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '
         . '[0-9]{4} '

--- a/test/Persistence/SessionCookieAwareTraitTest.php
+++ b/test/Persistence/SessionCookieAwareTraitTest.php
@@ -30,7 +30,7 @@ class SessionCookieAwareTraitTest extends TestCase
 {
     const EXPIRE_REGEXP = '/'
         . 'Expires\='
-        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sun), '
+        . '(Sun|Mon|Tue|Wed|Thu|Fri|Sat), '
         . '[0-3][0-9] '
         . '(Jan|Feb|Mar|Apr|May|Jun|Jul|Aug|Sep|Oct|Nov|Dec) '
         . '[0-9]{4} '


### PR DESCRIPTION
Integrate the "Configurable delete_cookie_on_empty_session" feature into the persistence traits.
This feature was added to mezzio-session-ext after the first persistence traits were implemented, so it was missing.
A regex bugfix in test cases is also included.

https://github.com/mezzio/mezzio-session/pull/9#issuecomment-703121233