### PR TITLE
Add PHP 8 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpunit.result.cache
 /clover.xml
 /composer.lock
 /coveralls-upload.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/.phpcs-cache
 /.phpunit.result.cache
 /clover.xml
 /composer.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,30 +6,30 @@ cache:
 
 env:
   global:
-    - COMPOSER_ARGS="--no-interaction"
+    - COMPOSER_ARGS="--no-interaction --ignore-platform-reqs"
     - COVERAGE_DEPS="php-coveralls/php-coveralls"
 
 matrix:
   fast_finish: true
   include:
-    - php: 7.1
+    - php: 7.3
       env:
         - DEPS=lowest
-    - php: 7.1
+    - php: 7.3
+      env:
+        - DEPS=latest
+    - php: 7.4
+      env:
+        - DEPS=lowest
+    - php: 7.4
       env:
         - DEPS=latest
         - CS_CHECK=true
         - TEST_COVERAGE=true
-    - php: 7.2
+    - php: nightly
       env:
         - DEPS=lowest
-    - php: 7.2
-      env:
-        - DEPS=latest
-    - php: 7.3
-      env:
-        - DEPS=lowest
-    - php: 7.3
+    - php: nightly
       env:
         - DEPS=latest
 

--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.1.0",
         "laminas/laminas-diactoros": "^2.2",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.json
+++ b/composer.json
@@ -27,8 +27,8 @@
         }
     },
     "require": {
-        "php": "^7.1",
-        "dflydev/fig-cookies": "^1.0.2 || ^2.0",
+        "php": "^7.3 || ~8.0.0",
+        "dflydev/fig-cookies": "^2.0.1",
         "laminas/laminas-zendframework-bridge": "^1.0",
         "psr/container": "^1.0",
         "psr/http-server-middleware": "^1.0"
@@ -36,10 +36,7 @@
     "require-dev": {
         "laminas/laminas-coding-standard": "~1.0.0",
         "laminas/laminas-diactoros": "^2.2",
-        "phpunit/phpunit": "^6.5.5"
-    },
-    "conflict": {
-        "phpspec/prophecy": "<1.7.2"
+        "phpunit/phpunit": "^9.3"
     },
     "suggest": {
         "mezzio/mezzio-csrf": "^1.0 || ^1.0-dev for CSRF protection capabilities",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,8 +1,20 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas Coding Standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+    
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
     <file>test</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,17 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-         bootstrap="vendor/autoload.php"
-         colors="true">
-    <testsuites>
-        <testsuite name="mezzio-session">
-            <directory>./test</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" bootstrap="vendor/autoload.php" colors="true">
+  <coverage processUncoveredFiles="true">
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="mezzio-session">
+      <directory>./test</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -10,21 +10,23 @@ declare(strict_types=1);
 
 namespace Mezzio\Session;
 
+use Zend\Expressive\Session\SessionMiddleware as LegacySessionMiddleware;
+
 class ConfigProvider
 {
-    public function __invoke() : array
+    public function __invoke(): array
     {
         return [
             'dependencies' => $this->getDependencies(),
         ];
     }
 
-    public function getDependencies() : array
+    public function getDependencies(): array
     {
         return [
             // Legacy Zend Framework aliases
-            'aliases' => [
-                \Zend\Expressive\Session\SessionMiddleware::class => SessionMiddleware::class,
+            'aliases'   => [
+                LegacySessionMiddleware::class => SessionMiddleware::class,
             ],
             'factories' => [
                 SessionMiddleware::class => SessionMiddlewareFactory::class,

--- a/src/Exception/InvalidHopsValueException.php
+++ b/src/Exception/InvalidHopsValueException.php
@@ -12,9 +12,11 @@ namespace Mezzio\Session\Exception;
 
 use InvalidArgumentException;
 
+use function sprintf;
+
 class InvalidHopsValueException extends InvalidArgumentException implements ExceptionInterface
 {
-    public static function valueTooLow(string $key, int $hops) : self
+    public static function valueTooLow(string $key, int $hops): self
     {
         return new self(sprintf(
             'Hops value specified for flash message "%s" was too low; must be greater than 0, received %d',

--- a/src/Exception/InvalidSessionSegmentDataException.php
+++ b/src/Exception/InvalidSessionSegmentDataException.php
@@ -12,12 +12,17 @@ namespace Mezzio\Session\Exception;
 
 use RuntimeException;
 
+use function get_class;
+use function gettype;
+use function is_object;
+use function sprintf;
+
 class InvalidSessionSegmentDataException extends RuntimeException implements ExceptionInterface
 {
     /**
      * @param mixed $data
      */
-    public static function whenRetrieving(string $name, $data) : self
+    public static function whenRetrieving(string $name, $data): self
     {
         return new self(sprintf(
             'Cannot retrieve session segment "%s"; data exists, but as a "%s" instead of an array',

--- a/src/Exception/NotInitializableException.php
+++ b/src/Exception/NotInitializableException.php
@@ -14,9 +14,12 @@ use Mezzio\Session\InitializePersistenceIdInterface;
 use Mezzio\Session\SessionPersistenceInterface;
 use RuntimeException;
 
+use function get_class;
+use function sprintf;
+
 final class NotInitializableException extends RuntimeException implements ExceptionInterface
 {
-    public static function invalidPersistence(SessionPersistenceInterface $persistence) : self
+    public static function invalidPersistence(SessionPersistenceInterface $persistence): self
     {
         return new self(sprintf(
             "Persistence '%s' does not implement '%s'",

--- a/src/Exception/SessionSegmentConflictException.php
+++ b/src/Exception/SessionSegmentConflictException.php
@@ -12,9 +12,11 @@ namespace Mezzio\Session\Exception;
 
 use RuntimeException;
 
+use function sprintf;
+
 class SessionSegmentConflictException extends RuntimeException implements ExceptionInterface
 {
-    public static function whenRetrieving(string $name) : self
+    public static function whenRetrieving(string $name): self
     {
         return new self(sprintf(
             'Retrieving session data "%s" via get(); however, this data refers to a session segment; aborting',
@@ -22,7 +24,7 @@ class SessionSegmentConflictException extends RuntimeException implements Except
         ));
     }
 
-    public static function whenSetting(string $name) : self
+    public static function whenSetting(string $name): self
     {
         return new self(sprintf(
             'Attempting to set session data "%s"; however, this data refers to a session segment; aborting',
@@ -30,7 +32,7 @@ class SessionSegmentConflictException extends RuntimeException implements Except
         ));
     }
 
-    public static function whenDeleting(string $name) : self
+    public static function whenDeleting(string $name): self
     {
         return new self(sprintf(
             'Attempting to unset session data "%s"; however, this data refers to a session segment. '

--- a/src/InitializePersistenceIdInterface.php
+++ b/src/InitializePersistenceIdInterface.php
@@ -14,9 +14,6 @@ interface InitializePersistenceIdInterface
 {
     /**
      * Returns new instance with id generated / regenerated, if required
-     *
-     * @param SessionInterface $session
-     * @return SessionInterface
      */
-    public function initializeId(SessionInterface $session) : SessionInterface;
+    public function initializeId(SessionInterface $session): SessionInterface;
 }

--- a/src/InitializeSessionIdInterface.php
+++ b/src/InitializeSessionIdInterface.php
@@ -6,7 +6,6 @@
  * @license   https://github.com/mezzio/mezzio-session/blob/master/LICENSE.md New BSD License
  */
 
-
 declare(strict_types=1);
 
 namespace Mezzio\Session;
@@ -15,8 +14,6 @@ interface InitializeSessionIdInterface
 {
     /**
      * Returns id of session, generating / regenerating if required
-     *
-     * @return string
      */
-    public function initializeId() : string;
+    public function initializeId(): string;
 }

--- a/src/LazySession.php
+++ b/src/LazySession.php
@@ -27,14 +27,10 @@ final class LazySession implements
     SessionInterface,
     InitializeSessionIdInterface
 {
-    /**
-     * @var SessionPersistenceInterface
-     */
+    /** @var SessionPersistenceInterface */
     private $persistence;
 
-    /**
-     * @var null|SessionInterface
-     */
+    /** @var null|SessionInterface */
     private $proxiedSession;
 
     /**
@@ -47,16 +43,16 @@ final class LazySession implements
     public function __construct(SessionPersistenceInterface $persistence, ServerRequestInterface $request)
     {
         $this->persistence = $persistence;
-        $this->request = $request;
+        $this->request     = $request;
     }
 
-    public function regenerate() : SessionInterface
+    public function regenerate(): SessionInterface
     {
         $this->proxiedSession = $this->getProxiedSession()->regenerate();
         return $this;
     }
 
-    public function isRegenerated() : bool
+    public function isRegenerated(): bool
     {
         if (! $this->proxiedSession) {
             return false;
@@ -65,37 +61,44 @@ final class LazySession implements
         return $this->proxiedSession->isRegenerated();
     }
 
-    public function toArray() : array
+    public function toArray(): array
     {
         return $this->getProxiedSession()->toArray();
     }
 
+    /**
+     * @param null|mixed $default
+     * @return mixed
+     */
     public function get(string $name, $default = null)
     {
         return $this->getProxiedSession()->get($name, $default);
     }
 
-    public function has(string $name) : bool
+    public function has(string $name): bool
     {
         return $this->getProxiedSession()->has($name);
     }
 
-    public function set(string $name, $value) : void
+    /**
+     * @param mixed $value
+     */
+    public function set(string $name, $value): void
     {
         $this->getProxiedSession()->set($name, $value);
     }
 
-    public function unset(string $name) : void
+    public function unset(string $name): void
     {
         $this->getProxiedSession()->unset($name);
     }
 
-    public function clear() : void
+    public function clear(): void
     {
         $this->getProxiedSession()->clear();
     }
 
-    public function hasChanged() : bool
+    public function hasChanged(): bool
     {
         if (! $this->proxiedSession) {
             return false;
@@ -113,7 +116,7 @@ final class LazySession implements
      *
      * @since 1.1.0
      */
-    public function getId() : string
+    public function getId(): string
     {
         $proxiedSession = $this->getProxiedSession();
         return $proxiedSession instanceof SessionIdentifierAwareInterface
@@ -126,7 +129,7 @@ final class LazySession implements
      *
      * @since 1.2.0
      */
-    public function persistSessionFor(int $duration) : void
+    public function persistSessionFor(int $duration): void
     {
         $proxiedSession = $this->getProxiedSession();
         if ($proxiedSession instanceof SessionCookiePersistenceInterface) {
@@ -139,7 +142,7 @@ final class LazySession implements
      *
      * @since 1.2.0
      */
-    public function getSessionLifetime() : int
+    public function getSessionLifetime(): int
     {
         $proxiedSession = $this->getProxiedSession();
         return $proxiedSession instanceof SessionCookiePersistenceInterface
@@ -157,8 +160,7 @@ final class LazySession implements
         return $this->proxiedSession->getId();
     }
 
-
-    private function getProxiedSession() : SessionInterface
+    private function getProxiedSession(): SessionInterface
     {
         if ($this->proxiedSession) {
             return $this->proxiedSession;

--- a/src/Persistence/CacheHeadersGeneratorTrait.php
+++ b/src/Persistence/CacheHeadersGeneratorTrait.php
@@ -48,13 +48,13 @@ trait CacheHeadersGeneratorTrait
         'private_no_expire' => true,
     ];
 
-    /** @var false|string */
+    /** @var bool|string */
     private $lastModified;
 
     /**
      * Add cache headers to the response when needed.
      */
-    private function addCacheHeadersToResponse(ResponseInterface $response) : ResponseInterface
+    private function addCacheHeadersToResponse(ResponseInterface $response): ResponseInterface
     {
         if (! $this->cacheLimiter || $this->responseAlreadyHasCacheHeaders($response)) {
             return $response;
@@ -74,7 +74,7 @@ trait CacheHeadersGeneratorTrait
      * Generate cache http headers for this instance's session cache-limiter and
      * cache-expire values.
      */
-    private function generateCacheHeaders() : array
+    private function generateCacheHeaders(): array
     {
         // Unsupported cache_limiter => do not generate cache headers
         if (! isset(self::$supportedCacheLimiters[$this->cacheLimiter])) {
@@ -131,7 +131,7 @@ trait CacheHeadersGeneratorTrait
             return $this->lastModified;
         }
 
-        $lastmod = getlastmod() ?: filemtime(__FILE__);
+        $lastmod            = getlastmod() ?: filemtime(__FILE__);
         $this->lastModified = $lastmod ? gmdate(Http::DATE_FORMAT, $lastmod) : false;
 
         return $this->lastModified;
@@ -140,7 +140,7 @@ trait CacheHeadersGeneratorTrait
     /**
      * Check if the response already carries cache headers
      */
-    private function responseAlreadyHasCacheHeaders(ResponseInterface $response) : bool
+    private function responseAlreadyHasCacheHeaders(ResponseInterface $response): bool
     {
         return $response->hasHeader('Expires')
             || $response->hasHeader('Last-Modified')

--- a/src/Persistence/Http.php
+++ b/src/Persistence/Http.php
@@ -20,6 +20,7 @@ class Http
      * values.
      *
      * òsee https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Date
+     *
      * @see https://tools.ietf.org/html/rfc7231#section-7.1.1.2
      */
     public const DATE_FORMAT = 'D, d M Y H:i:s T';

--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -69,7 +69,7 @@ trait SessionCookieAwareTrait
      * In each case, if the value is not found, it falls back to generating a
      * new session identifier.
      */
-    private function getSessionCookieValueFromRequest(ServerRequestInterface $request) : string
+    private function getSessionCookieValueFromRequest(ServerRequestInterface $request): string
     {
         if ('' === $request->getHeaderLine('Cookie')) {
             return $request->getCookieParams()[$this->cookieName] ?? '';
@@ -87,7 +87,7 @@ trait SessionCookieAwareTrait
         ResponseInterface $response,
         string $cookieValue,
         SessionInterface $session
-    ) : ResponseInterface {
+    ): ResponseInterface {
         return FigResponseCookies::set(
             $response,
             $this->createSessionCookieForResponse(
@@ -101,9 +101,9 @@ trait SessionCookieAwareTrait
      * Build a SetCookie instance for client session persistence.
      *
      * @param string $cookieValue The cookie value
-     * @param int|null $cookieLifetime A session cookie lifetime other than the default
+     * @param int    $cookieLifetime A session cookie lifetime other than the default
      */
-    private function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0) : SetCookie
+    private function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0): SetCookie
     {
         $sessionCookie = SetCookie::create($this->cookieName)
             ->withValue($cookieValue)
@@ -112,7 +112,8 @@ trait SessionCookieAwareTrait
             ->withSecure($this->cookieSecure)
             ->withHttpOnly($this->cookieHttpOnly);
 
-        if ($this->cookieSameSite
+        if (
+            $this->cookieSameSite
             && method_exists($sessionCookie, 'withSameSite')
             && class_exists(SameSite::class)
         ) {
@@ -130,14 +131,15 @@ trait SessionCookieAwareTrait
         return $sessionCookie;
     }
 
-    private function getSessionCookieLifetime(SessionInterface $session) : int
+    private function getSessionCookieLifetime(SessionInterface $session): int
     {
         if ($this->deleteCookieOnEmptySession && ! $session->toArray()) {
             return -(time() - 1);
         }
 
         $lifetime = (int) $this->cookieLifetime;
-        if ($session instanceof SessionCookiePersistenceInterface
+        if (
+            $session instanceof SessionCookiePersistenceInterface
             && $session->has(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY)
         ) {
             $lifetime = $session->getSessionLifetime();
@@ -148,6 +150,7 @@ trait SessionCookieAwareTrait
 
     /**
      * @internal
+     *
      * @return bool whether we delete cookie from browser when session becomes empty
      */
     public function isDeleteCookieOnEmptySession(): bool

--- a/src/Session.php
+++ b/src/Session.php
@@ -10,6 +10,8 @@ declare(strict_types=1);
 
 namespace Mezzio\Session;
 
+use stdClass;
+
 use function array_key_exists;
 use function json_decode;
 use function json_encode;
@@ -41,9 +43,7 @@ class Session implements
      */
     private $id;
 
-    /**
-     * @var bool
-     */
+    /** @var bool */
     private $isRegenerated = false;
 
     /**
@@ -63,7 +63,7 @@ class Session implements
     public function __construct(array $data, string $id = '')
     {
         $this->data = $this->originalData = $data;
-        $this->id = $id;
+        $this->id   = $id;
 
         if (isset($data[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY])) {
             $this->sessionLifetime = $data[SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY];
@@ -77,7 +77,7 @@ class Session implements
      * within a session are serializable across any session adapter.
      *
      * @param mixed $value
-     * @return null|bool|int|float|string|array|\stdClass
+     * @return null|bool|int|float|string|array|stdClass
      */
     public static function extractSerializableValue($value)
     {
@@ -87,13 +87,13 @@ class Session implements
     /**
      * Retrieve all data for purposes of persistence.
      */
-    public function toArray() : array
+    public function toArray(): array
     {
         return $this->data;
     }
 
     /**
-     * @param mixed $default Default value to return if $name does not exist.
+     * @param null|mixed $default Default value to return if $name does not exist.
      * @return mixed
      */
     public function get(string $name, $default = null)
@@ -101,7 +101,7 @@ class Session implements
         return $this->data[$name] ?? $default;
     }
 
-    public function has(string $name) : bool
+    public function has(string $name): bool
     {
         return array_key_exists($name, $this->data);
     }
@@ -109,22 +109,22 @@ class Session implements
     /**
      * @param mixed $value
      */
-    public function set(string $name, $value) : void
+    public function set(string $name, $value): void
     {
         $this->data[$name] = self::extractSerializableValue($value);
     }
 
-    public function unset(string $name) : void
+    public function unset(string $name): void
     {
         unset($this->data[$name]);
     }
 
-    public function clear() : void
+    public function clear(): void
     {
         $this->data = [];
     }
 
-    public function hasChanged() : bool
+    public function hasChanged(): bool
     {
         if ($this->isRegenerated) {
             return true;
@@ -133,14 +133,14 @@ class Session implements
         return $this->data !== $this->originalData;
     }
 
-    public function regenerate() : SessionInterface
+    public function regenerate(): SessionInterface
     {
-        $session = clone $this;
+        $session                = clone $this;
         $session->isRegenerated = true;
         return $session;
     }
 
-    public function isRegenerated() : bool
+    public function isRegenerated(): bool
     {
         return $this->isRegenerated;
     }
@@ -150,7 +150,7 @@ class Session implements
      *
      * @since 1.1.0
      */
-    public function getId() : string
+    public function getId(): string
     {
         return $this->id;
     }
@@ -160,7 +160,7 @@ class Session implements
      *
      * @since 1.2.0
      */
-    public function persistSessionFor(int $duration) : void
+    public function persistSessionFor(int $duration): void
     {
         $this->sessionLifetime = $duration;
         $this->set(SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY, $duration);
@@ -171,7 +171,7 @@ class Session implements
      *
      * @since 1.2.0
      */
-    public function getSessionLifetime() : int
+    public function getSessionLifetime(): int
     {
         return $this->sessionLifetime;
     }

--- a/src/SessionCookiePersistenceInterface.php
+++ b/src/SessionCookiePersistenceInterface.php
@@ -29,7 +29,7 @@ namespace Mezzio\Session;
  */
 interface SessionCookiePersistenceInterface
 {
-    const SESSION_LIFETIME_KEY = '__SESSION_TTL__';
+    public const SESSION_LIFETIME_KEY = '__SESSION_TTL__';
 
     /**
      * Define how long the session cookie should live.
@@ -48,7 +48,7 @@ interface SessionCookiePersistenceInterface
      *
      * @param int $duration Number of seconds the cookie should persist for.
      */
-    public function persistSessionFor(int $duration) : void;
+    public function persistSessionFor(int $duration): void;
 
     /**
      * Determine how long the session cookie should live.
@@ -66,5 +66,5 @@ interface SessionCookiePersistenceInterface
      *   and return it here. Typically, this value should be communicated via
      *   the SESSION_LIFETIME_KEY value of the session.
      */
-    public function getSessionLifetime() : int;
+    public function getSessionLifetime(): int;
 }

--- a/src/SessionIdentifierAwareInterface.php
+++ b/src/SessionIdentifierAwareInterface.php
@@ -23,5 +23,5 @@ interface SessionIdentifierAwareInterface
      *
      * @since 1.1.0
      */
-    public function getId() : string;
+    public function getId(): string;
 }

--- a/src/SessionInterface.php
+++ b/src/SessionInterface.php
@@ -15,12 +15,12 @@ interface SessionInterface
     /**
      * Serialize the session data to an array for storage purposes.
      */
-    public function toArray() : array;
+    public function toArray(): array;
 
     /**
      * Retrieve a value from the session.
      *
-     * @param mixed $default Default value to return if $name does not exist.
+     * @param null|mixed $default Default value to return if $name does not exist.
      * @return mixed
      */
     public function get(string $name, $default = null);
@@ -28,7 +28,7 @@ interface SessionInterface
     /**
      * Whether or not the container has the given key.
      */
-    public function has(string $name) : bool;
+    public function has(string $name): bool;
 
     /**
      * Set a value within the session.
@@ -38,23 +38,23 @@ interface SessionInterface
      *
      * @param mixed $value
      */
-    public function set(string $name, $value) : void;
+    public function set(string $name, $value): void;
 
     /**
      * Remove a value from the session.
      */
-    public function unset(string $name) : void;
+    public function unset(string $name): void;
 
     /**
      * Clear all values.
      */
-    public function clear() : void;
+    public function clear(): void;
 
     /**
      * Does the session contain changes? If not, the middleware handling
      * session persistence may not need to do more work.
      */
-    public function hasChanged() : bool;
+    public function hasChanged(): bool;
 
     /**
      * Regenerate the session.
@@ -67,11 +67,11 @@ interface SessionInterface
      * shipped LazySession, where instead it would return itself, after
      * internally re-setting the proxied session.
      */
-    public function regenerate(): SessionInterface;
+    public function regenerate(): self;
 
     /**
      * Method to determine if the session was regenerated; should return
      * true if the instance was produced via regenerate().
      */
-    public function isRegenerated() : bool;
+    public function isRegenerated(): bool;
 }

--- a/src/SessionMiddleware.php
+++ b/src/SessionMiddleware.php
@@ -19,9 +19,7 @@ class SessionMiddleware implements MiddlewareInterface
 {
     public const SESSION_ATTRIBUTE = 'session';
 
-    /**
-     * @var SessionPersistenceInterface
-     */
+    /** @var SessionPersistenceInterface */
     private $persistence;
 
     public function __construct(SessionPersistenceInterface $persistence)
@@ -29,9 +27,9 @@ class SessionMiddleware implements MiddlewareInterface
         $this->persistence = $persistence;
     }
 
-    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler) : ResponseInterface
+    public function process(ServerRequestInterface $request, RequestHandlerInterface $handler): ResponseInterface
     {
-        $session = new LazySession($this->persistence, $request);
+        $session  = new LazySession($this->persistence, $request);
         $response = $handler->handle(
             $request
                 ->withAttribute(self::SESSION_ATTRIBUTE, $session)

--- a/src/SessionMiddlewareFactory.php
+++ b/src/SessionMiddlewareFactory.php
@@ -14,7 +14,7 @@ use Psr\Container\ContainerInterface;
 
 class SessionMiddlewareFactory
 {
-    public function __invoke(ContainerInterface $container) : SessionMiddleware
+    public function __invoke(ContainerInterface $container): SessionMiddleware
     {
         return new SessionMiddleware(
             $container->get(SessionPersistenceInterface::class)

--- a/src/SessionPersistenceInterface.php
+++ b/src/SessionPersistenceInterface.php
@@ -18,7 +18,7 @@ interface SessionPersistenceInterface
     /**
      * Generate a session data instance based on the request.
      */
-    public function initializeSessionFromRequest(ServerRequestInterface $request) : SessionInterface;
+    public function initializeSessionFromRequest(ServerRequestInterface $request): SessionInterface;
 
     /**
      * Persist the session data instance.
@@ -26,5 +26,5 @@ interface SessionPersistenceInterface
      * Persists the session data, returning a response instance with any
      * artifacts required to return to the client.
      */
-    public function persistSession(SessionInterface $session, ResponseInterface $response) : ResponseInterface;
+    public function persistSession(SessionInterface $session, ResponseInterface $response): ResponseInterface;
 }

--- a/test/ConfigProviderTest.php
+++ b/test/ConfigProviderTest.php
@@ -15,24 +15,24 @@ use PHPUnit\Framework\TestCase;
 
 class ConfigProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         $this->provider = new ConfigProvider();
     }
 
-    public function testInvocationReturnsArray()
+    public function testInvocationReturnsArray(): array
     {
         $config = ($this->provider)();
-        $this->assertInternalType('array', $config);
+        $this->assertIsArray($config);
         return $config;
     }
 
     /**
      * @depends testInvocationReturnsArray
      */
-    public function testReturnedArrayContainsDependencies(array $config)
+    public function testReturnedArrayContainsDependencies(array $config): void
     {
         $this->assertArrayHasKey('dependencies', $config);
-        $this->assertInternalType('array', $config['dependencies']);
+        $this->assertIsArray($config['dependencies']);
     }
 }

--- a/test/LazySessionTest.php
+++ b/test/LazySessionTest.php
@@ -11,27 +11,36 @@ declare(strict_types=1);
 namespace MezzioTest\Session\LazySessionTest;
 
 use Mezzio\Session\Exception\NotInitializableException;
-use Mezzio\Session\InitializePersistenceIdInterface;
 use Mezzio\Session\LazySession;
 use Mezzio\Session\Session;
-use Mezzio\Session\SessionCookiePersistenceInterface;
-use Mezzio\Session\SessionIdentifierAwareInterface;
 use Mezzio\Session\SessionInterface;
 use Mezzio\Session\SessionPersistenceInterface;
 use MezzioTest\Session\TestAsset\SessionInitializationPersistenceInterface;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
-use Prophecy\Argument;
 use Psr\Http\Message\ServerRequestInterface;
 use ReflectionProperty;
 
 class LazySessionTest extends TestCase
 {
-    /** @var SessionInterface&\PHPUnit\Framework\MockObject\MockObject */
+    /**
+     * @var SessionInterface|MockObject
+     * @psalm-var SessionInterface&MockObject
+     */
     private $proxy;
-    /** @var SessionPersistenceInterface&\PHPUnit\Framework\MockObject\MockObject */
+
+    /**
+     * @var SessionPersistenceInterface|MockObject
+     * @psalm-var SessionPersistenceInterface&MockObject
+     */
     private $persistence;
-    /** @var ServerRequestInterface&\PHPUnit\Framework\MockObject\MockObject */
+
+    /**
+     * @var ServerRequestInterface|MockObject
+     * @psalm-var ServerRequestInterface&MockObject
+     */
     private $request;
+
     /** @var LazySession */
     private $session;
 
@@ -44,8 +53,10 @@ class LazySessionTest extends TestCase
     }
 
     /**
-     * @param SessionPersistenceInterface&\PHPUnit\Framework\MockObject\MockObject $persistence
-     * @param ServerRequestInterface&\PHPUnit\Framework\MockObject\MockObject $request
+     * @param SessionPersistenceInterface|MockObject $persistence
+     * @param ServerRequestInterface|MockObject      $request
+     * @psalm-param SessionPersistenceInterface&MockObject $persistence
+     * @psalm-param ServerRequestInterface&MockObject      $request
      */
     public function assertProxyCreated($persistence, $request): void
     {
@@ -257,7 +268,7 @@ class LazySessionTest extends TestCase
         $this->assertProxyCreated($persistence, $this->request);
 
         $session = new LazySession($persistence, $this->request);
-        $actual = $session->initializeId();
+        $actual  = $session->initializeId();
 
         $r = new ReflectionProperty($session, 'proxiedSession');
         $r->setAccessible(true);

--- a/test/Persistence/SessionCookieAwareTraitTest.php
+++ b/test/Persistence/SessionCookieAwareTraitTest.php
@@ -14,21 +14,25 @@ use Dflydev\FigCookies\Cookie;
 use Dflydev\FigCookies\FigRequestCookies;
 use Dflydev\FigCookies\Modifier\SameSite;
 use Dflydev\FigCookies\SetCookie;
-use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\Response;
+use Laminas\Diactoros\ServerRequest;
 use Laminas\Diactoros\ServerRequestFactory;
 use Mezzio\Session\Persistence\SessionCookieAwareTrait;
 use Mezzio\Session\Session;
 use Mezzio\Session\SessionInterface;
 use PHPUnit\Framework\TestCase;
-use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
 
+use function class_exists;
+use function method_exists;
+use function sprintf;
 use function strpos;
+use function urlencode;
 
 class SessionCookieAwareTraitTest extends TestCase
 {
-    const EXPIRE_REGEXP = '/'
+    public const EXPIRE_REGEXP = '/'
         . 'Expires\='
         . '(Sun|Mon|Tue|Wed|Thu|Fri|Sat), '
         . '[0-3][0-9] '
@@ -38,30 +42,30 @@ class SessionCookieAwareTraitTest extends TestCase
         . 'GMT'
     . '/i';
 
-    private const COOKIE_NAME = 'SESSIONCOOKIENAME';
-    private const COOKIE_LIFETIME = 0;
-    private const COOKIE_PATH = '/';
-    private const COOKIE_DOMAIN = null;
-    private const COOKIE_SECURE = false;
-    private const COOKIE_HTTPONLY = false;
-    private const COOKIE_SAMESITE = '';
+    private const COOKIE_NAME                    = 'SESSIONCOOKIENAME';
+    private const COOKIE_LIFETIME                = 0;
+    private const COOKIE_PATH                    = '/';
+    private const COOKIE_DOMAIN                  = null;
+    private const COOKIE_SECURE                  = false;
+    private const COOKIE_HTTPONLY                = false;
+    private const COOKIE_SAMESITE                = '';
     private const DELETE_COOKIE_ON_EMPTY_SESSION = false;
 
-    protected function setUp() : void
+    protected function setUp(): void
     {
     }
 
     protected function createConsumerInstance(
-        string $cookieName = null,
-        int $cookieLifetime = null,
-        string $cookiePath = null,
-        string $cookieDomain = null,
-        bool $cookieSecure = null,
-        bool $cookieHttpOnly = null,
-        string $cookieSameSite = null,
-        bool $deleteCookieOnEmptySession = null
+        ?string $cookieName = null,
+        ?int $cookieLifetime = null,
+        ?string $cookiePath = null,
+        ?string $cookieDomain = null,
+        ?bool $cookieSecure = null,
+        ?bool $cookieHttpOnly = null,
+        ?string $cookieSameSite = null,
+        ?bool $deleteCookieOnEmptySession = null
     ): object {
-        return new class(
+        return new class (
             $cookieName ?? self::COOKIE_NAME,
             $cookieLifetime ?? self::COOKIE_LIFETIME,
             $cookiePath ?? self::COOKIE_PATH,
@@ -83,23 +87,23 @@ class SessionCookieAwareTraitTest extends TestCase
                 string $cookieName,
                 int $cookieLifetime = 0,
                 string $cookiePath = '/',
-                string $cookieDomain = null,
+                ?string $cookieDomain = null,
                 bool $cookieSecure = false,
                 bool $cookieHttpOnly = false,
                 string $cookieSameSite = '',
                 bool $deleteCookieOnEmptySession = false
             ) {
-                $this->cookieName     = $cookieName;
-                $this->cookieLifetime = $cookieLifetime;
-                $this->cookiePath     = $cookiePath;
-                $this->cookieDomain   = $cookieDomain;
-                $this->cookieSecure   = $cookieSecure;
-                $this->cookieHttpOnly = $cookieHttpOnly;
-                $this->cookieSameSite = $cookieSameSite;
+                $this->cookieName                 = $cookieName;
+                $this->cookieLifetime             = $cookieLifetime;
+                $this->cookiePath                 = $cookiePath;
+                $this->cookieDomain               = $cookieDomain;
+                $this->cookieSecure               = $cookieSecure;
+                $this->cookieHttpOnly             = $cookieHttpOnly;
+                $this->cookieSameSite             = $cookieSameSite;
                 $this->deleteCookieOnEmptySession = $deleteCookieOnEmptySession;
             }
 
-            public function getSessionCookieValueFromRequest(ServerRequestInterface $request) : string
+            public function getSessionCookieValueFromRequest(ServerRequestInterface $request): string
             {
                 return $this->trait_getSessionCookieValueFromRequest($request);
             }
@@ -108,21 +112,21 @@ class SessionCookieAwareTraitTest extends TestCase
                 ResponseInterface $response,
                 string $cookieValue,
                 SessionInterface $session
-            ) : ResponseInterface {
+            ): ResponseInterface {
                 return $this->trait_addSessionCookieHeaderToResponse($response, $cookieValue, $session);
             }
 
-            public function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0) : SetCookie
+            public function createSessionCookieForResponse(string $cookieValue, int $cookieLifetime = 0): SetCookie
             {
                 return $this->trait_createSessionCookieForResponse($cookieValue, $cookieLifetime);
             }
 
-            public function getSessionCookieLifetime(SessionInterface $session) : int
+            public function getSessionCookieLifetime(SessionInterface $session): int
             {
                 return $this->trait_getSessionCookieLifetime($session);
             }
 
-            public function isDeleteCookieOnEmptySession() : bool
+            public function isDeleteCookieOnEmptySession(): bool
             {
                 return $this->trait_isDeleteCookieOnEmptySession();
             }
@@ -134,8 +138,8 @@ class SessionCookieAwareTraitTest extends TestCase
      */
     public function testGetSessionCookieValueFromRequestUsingInjectesCookieParams(
         string $cookieName,
-        string $cookieValue = null,
-        string $expected = null
+        ?string $cookieValue = null,
+        ?string $expected = null
     ): void {
         $consumer = $this->createConsumerInstance($cookieName);
 
@@ -150,12 +154,12 @@ class SessionCookieAwareTraitTest extends TestCase
      */
     public function testGetSessionCookieValueFromRequestUsingInjectedCookieHeader(
         string $cookieName,
-        string $cookieValue = null,
-        string $expected = null
+        ?string $cookieValue = null,
+        ?string $expected = null
     ): void {
         $consumer = $this->createConsumerInstance($cookieName);
 
-        $cookie = Cookie::create($cookieName, $cookieValue);
+        $cookie  = Cookie::create($cookieName, $cookieValue);
         $request = FigRequestCookies::set(new ServerRequest(), $cookie);
 
         self::assertSame($expected, $consumer->getSessionCookieValueFromRequest($request));
@@ -176,8 +180,8 @@ class SessionCookieAwareTraitTest extends TestCase
 
     public function testAddSessionCookieHeaderToResponse(): void
     {
-        $cookieName  = 'ADDSESSIONCOOKIEID';
-        $cookieValue = 'set-some-cookie-value';
+        $cookieName      = 'ADDSESSIONCOOKIEID';
+        $cookieValue     = 'set-some-cookie-value';
         $sessionLifetime = 3600;
 
         $consumer = $this->createConsumerInstance($cookieName);
@@ -202,7 +206,7 @@ class SessionCookieAwareTraitTest extends TestCase
         int $cookieLifetime,
         string $expectedHeaderLine
     ): void {
-        $consumer = $this->createConsumerInstance($cookieName);
+        $consumer  = $this->createConsumerInstance($cookieName);
         $setCookie = $consumer->createSessionCookieForResponse(
             $cookieValue ?? '',
             $cookieLifetime ?? 0
@@ -220,7 +224,7 @@ class SessionCookieAwareTraitTest extends TestCase
         $cookieWeirdValue = '!"£$%&/';
 
         return [
-            [$cookieName, null,              0, sprintf('%s=; Path=/',   $cookieName)],
+            [$cookieName, null,              0, sprintf('%s=; Path=/', $cookieName)],
             [$cookieName, $cookieNiceValue,  0, sprintf('%s=%s; Path=/', $cookieName, $cookieNiceValue)],
             [$cookieName, $cookieWeirdValue, 0, sprintf('%s=%s; Path=/', $cookieName, urlencode($cookieWeirdValue))],
         ];
@@ -305,9 +309,9 @@ class SessionCookieAwareTraitTest extends TestCase
      * @dataProvider provideSessionCookieLifetimeValues
      */
     public function testGetSessionCookieLifetimeReturnsExpectedResults(
-        int $cookieLifetime = null,
-        int $sessionLifetime = null,
-        int $expected = null
+        ?int $cookieLifetime = null,
+        ?int $sessionLifetime = null,
+        ?int $expected = null
     ): void {
         $consumer = $this->createConsumerInstance('SESSIONCOOKIENAME', $cookieLifetime ?? 0);
         $session  = new Session([]);

--- a/test/SessionMiddlewareTest.php
+++ b/test/SessionMiddlewareTest.php
@@ -50,7 +50,7 @@ class SessionMiddlewareTest extends TestCase
 
     public function testMiddlewareCreatesLazySessionAndPassesItToDelegateAndPersistsSessionInResponse(): void
     {
-        /** @var ServerRequestInterface&\PHPUnit\Framework\MockObject\MockObject $request */
+        /** @psalm-var ServerRequestInterface&\PHPUnit\Framework\MockObject\MockObject $request */
         $request = $this->createMock(ServerRequestInterface::class);
         $request
             ->expects($this->exactly(2))
@@ -61,10 +61,10 @@ class SessionMiddlewareTest extends TestCase
             )
             ->willReturnSelf();
 
-        /** @var ResponseInterface&\PHPUnit\Framework\MockObject\MockObject $response */
+        /** @psalm-var ResponseInterface&\PHPUnit\Framework\MockObject\MockObject $response */
         $response = $this->createMock(ResponseInterface::class);
 
-        /** @var RequestHandlerInterface&\PHPUnit\Framework\MockObject\MockObject $handler */
+        /** @psalm-var RequestHandlerInterface&\PHPUnit\Framework\MockObject\MockObject $handler */
         $handler = $this->createMock(RequestHandlerInterface::class);
         $handler
             ->expects($this->once())
@@ -72,7 +72,7 @@ class SessionMiddlewareTest extends TestCase
             ->with($request)
             ->willReturn($response);
 
-        /** @var SessionPersistenceInterface&\PHPUnit\Framework\MockObject\MockObject $persistence */
+        /** @psalm-var SessionPersistenceInterface&\PHPUnit\Framework\MockObject\MockObject $persistence */
         $persistence = $this->createMock(SessionPersistenceInterface::class);
         $persistence
             ->expects($this->once())

--- a/test/SessionTest.php
+++ b/test/SessionTest.php
@@ -18,25 +18,25 @@ use PHPUnit\Framework\TestCase;
 
 class SessionTest extends TestCase
 {
-    public function testImplementsSessionInterface()
+    public function testImplementsSessionInterface(): void
     {
         $session = new Session([]);
         $this->assertInstanceOf(SessionInterface::class, $session);
     }
 
-    public function testIsNotChangedAtInstantiation()
+    public function testIsNotChangedAtInstantiation(): void
     {
         $session = new Session([]);
         $this->assertFalse($session->hasChanged());
     }
 
-    public function testIsNotRegeneratedByDefault()
+    public function testIsNotRegeneratedByDefault(): void
     {
         $session = new Session([]);
         $this->assertFalse($session->isRegenerated());
     }
 
-    public function testRegenerateProducesANewInstance()
+    public function testRegenerateProducesANewInstance(): Session
     {
         $session = new Session([]);
         $regenerated = $session->regenerate();
@@ -47,7 +47,7 @@ class SessionTest extends TestCase
     /**
      * @depends testRegenerateProducesANewInstance
      */
-    public function testRegeneratedSessionReturnsTrueForIsRegenerated(SessionInterface $session)
+    public function testRegeneratedSessionReturnsTrueForIsRegenerated(SessionInterface $session): void
     {
         $this->assertTrue($session->isRegenerated());
     }
@@ -55,12 +55,12 @@ class SessionTest extends TestCase
     /**
      * @depends testRegenerateProducesANewInstance
      */
-    public function testRegeneratedSessionIsChanged(SessionInterface $session)
+    public function testRegeneratedSessionIsChanged(SessionInterface $session): void
     {
         $this->assertTrue($session->hasChanged());
     }
 
-    public function testSettingDataInSessionMakesItAccessible()
+    public function testSettingDataInSessionMakesItAccessible(): Session
     {
         $session = new Session([]);
         $this->assertFalse($session->has('foo'));
@@ -73,7 +73,7 @@ class SessionTest extends TestCase
     /**
      * @depends testSettingDataInSessionMakesItAccessible
      */
-    public function testSettingDataInSessionChangesSession(SessionInterface $session)
+    public function testSettingDataInSessionChangesSession(SessionInterface $session): void
     {
         $this->assertTrue($session->hasChanged());
     }
@@ -81,7 +81,7 @@ class SessionTest extends TestCase
     /**
      * @depends testSettingDataInSessionMakesItAccessible
      */
-    public function testToArrayReturnsAllDataPreviouslySet(SessionInterface $session)
+    public function testToArrayReturnsAllDataPreviouslySet(SessionInterface $session): void
     {
         $this->assertSame(['foo' => 'bar'], $session->toArray());
     }
@@ -89,13 +89,13 @@ class SessionTest extends TestCase
     /**
      * @depends testSettingDataInSessionMakesItAccessible
      */
-    public function testCanUnsetDataInSession(SessionInterface $session)
+    public function testCanUnsetDataInSession(SessionInterface $session): void
     {
         $session->unset('foo');
         $this->assertFalse($session->has('foo'));
     }
 
-    public function testClearingSessionRemovesAllData()
+    public function testClearingSessionRemovesAllData(): void
     {
         $original = [
             'foo' => 'bar',
@@ -109,7 +109,7 @@ class SessionTest extends TestCase
         $this->assertSame([], $session->toArray());
     }
 
-    public function serializedDataProvider() : iterable
+    public function serializedDataProvider(): iterable
     {
         $data = (object) ['test_case' => $this];
         $expected = json_decode(json_encode($data, \JSON_PRESERVE_ZERO_FRACTION), true);
@@ -119,7 +119,7 @@ class SessionTest extends TestCase
     /**
      * @dataProvider serializedDataProvider
      */
-    public function testSetEnsuresDataIsJsonSerializable($data, $expected)
+    public function testSetEnsuresDataIsJsonSerializable($data, $expected): void
     {
         $session = new Session([]);
         $session->set('foo', $data);
@@ -127,44 +127,44 @@ class SessionTest extends TestCase
         $this->assertSame($expected, $session->get('foo'));
     }
 
-    public function testImplementsSessionIdentifierAwareInterface()
+    public function testImplementsSessionIdentifierAwareInterface(): void
     {
         $session = new Session([]);
         $this->assertInstanceOf(SessionIdentifierAwareInterface::class, $session);
     }
 
-    public function testGetIdReturnsEmptyStringIfNoIdentifierProvidedToConstructor()
+    public function testGetIdReturnsEmptyStringIfNoIdentifierProvidedToConstructor(): void
     {
         $session = new Session([]);
         $this->assertSame('', $session->getId());
     }
 
-    public function testGetIdReturnsValueProvidedToConstructor()
+    public function testGetIdReturnsValueProvidedToConstructor(): void
     {
         $session = new Session([], '1234abcd');
         $this->assertSame('1234abcd', $session->getId());
     }
 
-    public function testImplementsSessionCookiePersistenceInterface()
+    public function testImplementsSessionCookiePersistenceInterface(): void
     {
         $session = new Session([]);
         $this->assertInstanceOf(SessionCookiePersistenceInterface::class, $session);
     }
 
-    public function testDefaultSessionCookieLifetimeIsZero()
+    public function testDefaultSessionCookieLifetimeIsZero(): void
     {
         $session = new Session([]);
         $this->assertSame(0, $session->getSessionLifetime());
     }
 
-    public function testAllowsSettingCookieLifetime()
+    public function testAllowsSettingCookieLifetime(): void
     {
         $session = new Session([]);
         $session->persistSessionFor(60);
         $this->assertSame(60, $session->getSessionLifetime());
     }
 
-    public function testGetSessionLifetimeReturnsValueOfSessionLifetimeKeyWhenPresentInSession()
+    public function testGetSessionLifetimeReturnsValueOfSessionLifetimeKeyWhenPresentInSession(): void
     {
         $session = new Session([
             SessionCookiePersistenceInterface::SESSION_LIFETIME_KEY => 60,
@@ -172,7 +172,7 @@ class SessionTest extends TestCase
         $this->assertSame(60, $session->getSessionLifetime());
     }
 
-    public function testPersistingSessionCookieLifetimeSetsLifetimeKeyInSessionData()
+    public function testPersistingSessionCookieLifetimeSetsLifetimeKeyInSessionData(): void
     {
         $session = new Session([]);
         $session->persistSessionFor(60);

--- a/test/SessionTest.php
+++ b/test/SessionTest.php
@@ -16,6 +16,11 @@ use Mezzio\Session\SessionIdentifierAwareInterface;
 use Mezzio\Session\SessionInterface;
 use PHPUnit\Framework\TestCase;
 
+use function json_decode;
+use function json_encode;
+
+use const JSON_PRESERVE_ZERO_FRACTION;
+
 class SessionTest extends TestCase
 {
     public function testImplementsSessionInterface(): void
@@ -38,7 +43,7 @@ class SessionTest extends TestCase
 
     public function testRegenerateProducesANewInstance(): Session
     {
-        $session = new Session([]);
+        $session     = new Session([]);
         $regenerated = $session->regenerate();
         $this->assertNotSame($session, $regenerated);
         return $regenerated;
@@ -101,7 +106,7 @@ class SessionTest extends TestCase
             'foo' => 'bar',
             'baz' => 'bat',
         ];
-        $session = new Session($original);
+        $session  = new Session($original);
         $this->assertSame($original, $session->toArray());
 
         $session->clear();
@@ -111,15 +116,15 @@ class SessionTest extends TestCase
 
     public function serializedDataProvider(): iterable
     {
-        $data = (object) ['test_case' => $this];
-        $expected = json_decode(json_encode($data, \JSON_PRESERVE_ZERO_FRACTION), true);
+        $data     = (object) ['test_case' => $this];
+        $expected = json_decode(json_encode($data, JSON_PRESERVE_ZERO_FRACTION), true);
         yield 'nested-objects' => [$data, $expected];
     }
 
     /**
      * @dataProvider serializedDataProvider
      */
-    public function testSetEnsuresDataIsJsonSerializable($data, $expected): void
+    public function testSetEnsuresDataIsJsonSerializable(object $data, array $expected): void
     {
         $session = new Session([]);
         $session->set('foo', $data);

--- a/test/TestAsset/SessionInitializationPersistenceInterface.php
+++ b/test/TestAsset/SessionInitializationPersistenceInterface.php
@@ -1,0 +1,20 @@
+<?php
+
+/**
+ * @see       https://github.com/mezzio/mezzio-session for the canonical source repository
+ * @copyright https://github.com/mezzio/mezzio-session/blob/master/COPYRIGHT.md
+ * @license   https://github.com/mezzio/mezzio-session/blob/master/LICENSE.md New BSD License
+ */
+
+declare(strict_types=1);
+
+namespace MezzioTest\Session\TestAsset;
+
+use Mezzio\Session\InitializePersistenceIdInterface;
+use Mezzio\Session\SessionPersistenceInterface;
+
+interface SessionInitializationPersistenceInterface extends
+    SessionPersistenceInterface,
+    InitializePersistenceIdInterface
+{
+}


### PR DESCRIPTION
- Updates PHP constraint to `^7.3 || ~8.0.0`
- Updates PHPUnit constraint to `^9.3`
- Removes constraint for phpspec/prophecy
- Updates Travis job matrix to cover 7.3, 7.4, and 8.0
- Migrates tests from Prophecy to PHPUnit mocks
- Extracts data providers where they make sense, and re-enables a test case that had been commented out
- Updates coding standard constraint to `~2.1.0` and applies it to the code base

Fixes #12 
