### PR TITLE
1.4.x code updates

### DIFF
--- a/src/Persistence/SessionCookieAwareTrait.php
+++ b/src/Persistence/SessionCookieAwareTrait.php
@@ -19,8 +19,6 @@ use Mezzio\Session\SessionInterface;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 
-use function class_exists;
-use function method_exists;
 use function time;
 
 /**
@@ -112,11 +110,7 @@ trait SessionCookieAwareTrait
             ->withSecure($this->cookieSecure)
             ->withHttpOnly($this->cookieHttpOnly);
 
-        if (
-            $this->cookieSameSite
-            && method_exists($sessionCookie, 'withSameSite')
-            && class_exists(SameSite::class)
-        ) {
+        if ($this->cookieSameSite) {
             $sessionCookie = $sessionCookie->withSameSite(
                 SameSite::fromString($this->cookieSameSite)
             );

--- a/test/Persistence/SessionCookieAwareTraitTest.php
+++ b/test/Persistence/SessionCookieAwareTraitTest.php
@@ -27,7 +27,6 @@ use Psr\Http\Message\ServerRequestInterface;
 use function class_exists;
 use function method_exists;
 use function sprintf;
-use function strpos;
 use function urlencode;
 
 class SessionCookieAwareTraitTest extends TestCase
@@ -346,7 +345,7 @@ class SessionCookieAwareTraitTest extends TestCase
         $cookieName  = 'SESSIONCOOKIENAME';
         $cookieValue = 'session-cookie-value';
 
-        $consumer = $this->createConsumerInstance('SESSIONCOOKIENAME', null, null, null, null, null, null, true);
+        $consumer = $this->createConsumerInstance($cookieName, null, null, null, null, null, null, true);
         $session  = new Session(['foo' => 'bar']);
         $session->clear();
         $response = $consumer->addSessionCookieHeaderToResponse(new Response(), $cookieValue, $session);
@@ -354,6 +353,6 @@ class SessionCookieAwareTraitTest extends TestCase
         $cookieString = $response->getHeaderLine('Set-Cookie');
         $this->assertIsString($cookieString);
         $expiresString = 'Expires=Thu, 01 Jan 1970 00:00:01 GMT';
-        $this->assertNotFalse(strpos($cookieString, $expiresString), 'cookie should bet set to expire in the past');
+        $this->assertStringContainsString($expiresString, $cookieString, 'cookie should bet set to expire in the past');
     }
 }


### PR DESCRIPTION
- Remove unnecessary checks since dflydev/fig-cookies version requirement is now >= 2 where SameSIte is supported
- Use new and more descriptive phpunit assertion method as was done [here](https://github.com/mezzio/mezzio-session-ext/blob/7e106f167f1af4e6a66ffb106ade4be0b32645b2/test/PhpSessionPersistenceTest.php#L991)
- minor code update for unused var