### PR TITLE
Allow `psr/container:^2`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,7 @@
     "require": {
         "php": "^7.3 || ~8.0.0 || ~8.1.0",
         "dflydev/fig-cookies": "^2.0.1 || ^3.0",
-        "psr/container": "^1.0",
+        "psr/container": "^1.0|^2.0",
         "psr/http-server-middleware": "^1.0"
     },
     "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7ab23e80baf43727fe7af2944e71598",
+    "content-hash": "f0341d652d8da3191160ec76b705fe14",
     "packages": [
         {
             "name": "dflydev/fig-cookies",


### PR DESCRIPTION
Only requires new minor version.

See hannesvdvreken/psr-container-v2-demonstrator#1 for an explanation.
