### PR TITLE
Update Session parameter docs for `SessionPersistenceInterface`

### DIFF
--- a/src/SessionPersistenceInterface.php
+++ b/src/SessionPersistenceInterface.php
@@ -19,6 +19,8 @@ interface SessionPersistenceInterface
      *
      * Persists the session data, returning a response instance with any
      * artifacts required to return to the client.
+     *
+     * @param SessionInterface&SessionIdentifierAwareInterface $session
      */
     public function persistSession(SessionInterface $session, ResponseInterface $response): ResponseInterface;
 }


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes

### Description

Until 2.0 is released, persistence implementations generally need to know what the session id is with `$session->getId()` inside their `persistSession` implementation. This changes the expected parameter to an intersection of `SessionInterface&SessionIdentifierAwareInterface`
