### PR TITLE
`redirect_maps` should be a `dict`, not a list

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -22,8 +22,8 @@ extra:
 plugins:
     - redirects:
         redirect_maps:
-            - intro.md: v1/intro.md
-            - installation.md: v1/installation.md
-            - session.md: v1/session.md
-            - persistence.md: v1/persistence.md
-            - middleware.md: v1/middleware.md
+            intro.md: v1/intro.md
+            installation.md: v1/installation.md
+            session.md: v1/session.md
+            persistence.md: v1/persistence.md
+            middleware.md: v1/middleware.md


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation | yes
| Bugfix        | yes